### PR TITLE
If no workloads for the node, move to end

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -75,7 +75,7 @@ type Workloads interface {
 	SignProvision(id schema.ID, user schema.ID, signature string) error
 	SignDelete(id schema.ID, user schema.ID, signature string) error
 
-	Workloads(nodeID string, from uint64) ([]workloads.ReservationWorkload, error)
+	Workloads(nodeID string, from uint64) ([]workloads.ReservationWorkload, uint64, error)
 	WorkloadGet(gwid string) (result workloads.ReservationWorkload, err error)
 	WorkloadPutResult(nodeID, gwid string, result workloads.Result) error
 	WorkloadPutDeleted(nodeID, gwid string) error

--- a/client/directory.go
+++ b/client/directory.go
@@ -20,12 +20,13 @@ func (d *httpDirectory) FarmRegister(farm directory.Farm) (schema.ID, error) {
 		ID schema.ID `json:"id"`
 	}
 
-	err := d.post(d.url("farms"), farm, &output, http.StatusCreated)
+	_, err := d.post(d.url("farms"), farm, &output, http.StatusCreated)
 	return output.ID, err
 }
 
 func (d *httpDirectory) FarmUpdate(farm directory.Farm) error {
-	return d.put(d.url("farms", fmt.Sprintf("%d", farm.ID)), farm, nil, http.StatusOK)
+	_, err := d.put(d.url("farms", fmt.Sprintf("%d", farm.ID)), farm, nil, http.StatusOK)
+	return err
 }
 
 func (d *httpDirectory) FarmList(tid schema.ID, name string, page *Pager) (farms []directory.Farm, err error) {
@@ -37,35 +38,37 @@ func (d *httpDirectory) FarmList(tid schema.ID, name string, page *Pager) (farms
 	if len(name) != 0 {
 		query.Set("name", name)
 	}
-	err = d.get(d.url("farms"), query, &farms, http.StatusOK)
+	_, err = d.get(d.url("farms"), query, &farms, http.StatusOK)
 	return
 }
 
 func (d *httpDirectory) FarmGet(id schema.ID) (farm directory.Farm, err error) {
-	err = d.get(d.url("farms", fmt.Sprint(id)), nil, &farm, http.StatusOK)
+	_, err = d.get(d.url("farms", fmt.Sprint(id)), nil, &farm, http.StatusOK)
 	return
 }
 
 func (d *httpDirectory) NodeRegister(node directory.Node) error {
-	return d.post(d.url("nodes"), node, nil, http.StatusCreated)
+	_, err := d.post(d.url("nodes"), node, nil, http.StatusCreated)
+	return err
 }
 
 func (d *httpDirectory) NodeList(filter NodeFilter) (nodes []directory.Node, err error) {
 	query := url.Values{}
 	filter.Apply(query)
-	err = d.get(d.url("nodes"), query, &nodes, http.StatusOK)
+	_, err = d.get(d.url("nodes"), query, &nodes, http.StatusOK)
 	return
 }
 
 func (d *httpDirectory) NodeGet(id string, proofs bool) (node directory.Node, err error) {
 	query := url.Values{}
 	query.Set("proofs", fmt.Sprint(proofs))
-	err = d.get(d.url("nodes", id), query, &node, http.StatusOK)
+	_, err = d.get(d.url("nodes", id), query, &node, http.StatusOK)
 	return
 }
 
 func (d *httpDirectory) NodeSetInterfaces(id string, ifaces []directory.Iface) error {
-	return d.post(d.url("nodes", id, "interfaces"), ifaces, nil, http.StatusCreated)
+	_, err := d.post(d.url("nodes", id, "interfaces"), ifaces, nil, http.StatusCreated)
+	return err
 }
 
 func (d *httpDirectory) NodeSetPorts(id string, ports []uint) error {
@@ -74,11 +77,13 @@ func (d *httpDirectory) NodeSetPorts(id string, ports []uint) error {
 	}
 	input.P = ports
 
-	return d.post(d.url("nodes", id, "ports"), input, nil, http.StatusOK)
+	_, err := d.post(d.url("nodes", id, "ports"), input, nil, http.StatusOK)
+	return err
 }
 
 func (d *httpDirectory) NodeSetPublic(id string, pub directory.PublicIface) error {
-	return d.post(d.url("nodes", id, "configure_public"), pub, nil, http.StatusCreated)
+	_, err := d.post(d.url("nodes", id, "configure_public"), pub, nil, http.StatusCreated)
+	return err
 }
 
 func (d *httpDirectory) NodeSetCapacity(
@@ -100,7 +105,8 @@ func (d *httpDirectory) NodeSetCapacity(
 		Hypervisor: hypervisor,
 	}
 
-	return d.post(d.url("nodes", id, "capacity"), payload, nil, http.StatusOK)
+	_, err := d.post(d.url("nodes", id, "capacity"), payload, nil, http.StatusOK)
+	return err
 }
 
 func (d *httpDirectory) NodeUpdateUptime(id string, uptime uint64) error {
@@ -110,7 +116,8 @@ func (d *httpDirectory) NodeUpdateUptime(id string, uptime uint64) error {
 		U: uptime,
 	}
 
-	return d.post(d.url("nodes", id, "uptime"), input, nil, http.StatusOK)
+	_, err := d.post(d.url("nodes", id, "uptime"), input, nil, http.StatusOK)
+	return err
 }
 
 func (d *httpDirectory) NodeUpdateUsedResources(id string, resources directory.ResourceAmount, workloads directory.WorkloadAmount) error {
@@ -121,7 +128,8 @@ func (d *httpDirectory) NodeUpdateUsedResources(id string, resources directory.R
 		resources,
 		workloads,
 	}
-	return d.post(d.url("nodes", id, "used_resources"), input, nil, http.StatusOK)
+	_, err := d.post(d.url("nodes", id, "used_resources"), input, nil, http.StatusOK)
+	return err
 }
 
 func (d *httpDirectory) NodeSetFreeToUse(id string, free bool) error {
@@ -129,11 +137,13 @@ func (d *httpDirectory) NodeSetFreeToUse(id string, free bool) error {
 		FreeToUse bool `json:"free_to_use"`
 	}{FreeToUse: free}
 
-	return d.post(d.url("nodes", id, "configure_free"), choice, nil, http.StatusOK)
+	_, err := d.post(d.url("nodes", id, "configure_free"), choice, nil, http.StatusOK)
+	return err
 }
 
 func (d *httpDirectory) GatewayRegister(Gateway directory.Gateway) error {
-	return d.post(d.url("gateways"), Gateway, nil, http.StatusCreated)
+	_, err := d.post(d.url("gateways"), Gateway, nil, http.StatusCreated)
+	return err
 }
 
 func (d *httpDirectory) GatewayList(tid schema.ID, name string, page *Pager) (Gateways []directory.Gateway, err error) {
@@ -142,12 +152,12 @@ func (d *httpDirectory) GatewayList(tid schema.ID, name string, page *Pager) (Ga
 	if len(name) != 0 {
 		query.Set("name", name)
 	}
-	err = d.get(d.url("gateways"), query, &Gateways, http.StatusOK)
+	_, err = d.get(d.url("gateways"), query, &Gateways, http.StatusOK)
 	return
 }
 
 func (d *httpDirectory) GatewayGet(id string) (Gateway directory.Gateway, err error) {
-	err = d.get(d.url("gateways", id), nil, &Gateway, http.StatusOK)
+	_, err = d.get(d.url("gateways", id), nil, &Gateway, http.StatusOK)
 	return
 }
 
@@ -158,7 +168,8 @@ func (d *httpDirectory) GatewayUpdateUptime(id string, uptime uint64) error {
 		U: uptime,
 	}
 
-	return d.post(d.url("gateways", id, "uptime"), input, nil, http.StatusOK)
+	_, err := d.post(d.url("gateways", id, "uptime"), input, nil, http.StatusOK)
+	return err
 }
 
 func (d *httpDirectory) GatewayUpdateReservedResources(id string, resources directory.ResourceAmount, workloads directory.WorkloadAmount) error {
@@ -169,5 +180,7 @@ func (d *httpDirectory) GatewayUpdateReservedResources(id string, resources dire
 		resources,
 		workloads,
 	}
-	return d.post(d.url("gateways", id, "reserved_resources"), input, nil, http.StatusOK)
+
+	_, err := d.post(d.url("gateways", id, "reserved_resources"), input, nil, http.StatusOK)
+	return err
 }

--- a/client/http.go
+++ b/client/http.go
@@ -128,89 +128,89 @@ func (c *httpClient) process(response *http.Response, output interface{}, expect
 	return nil
 }
 
-func (c *httpClient) post(u string, input interface{}, output interface{}, expect ...int) error {
+func (c *httpClient) post(u string, input interface{}, output interface{}, expect ...int) (*http.Response, error) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(input); err != nil {
-		return errors.Wrap(err, "failed to serialize request body")
+		return nil, errors.Wrap(err, "failed to serialize request body")
 	}
 
 	req, err := http.NewRequest(http.MethodPost, u, &buf)
 	if err != nil {
-		return errors.Wrap(err, "failed to create new HTTP request")
+		return nil, errors.Wrap(err, "failed to create new HTTP request")
 	}
 
 	if err := c.sign(req); err != nil {
-		return errors.Wrap(err, "failed to sign HTTP request")
+		return nil, errors.Wrap(err, "failed to sign HTTP request")
 	}
 	response, err := c.cl.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "failed to send request")
+		return nil, errors.Wrap(err, "failed to send request")
 	}
 
-	return c.process(response, output, expect...)
+	return response, c.process(response, output, expect...)
 }
 
-func (c *httpClient) put(u string, input interface{}, output interface{}, expect ...int) error {
+func (c *httpClient) put(u string, input interface{}, output interface{}, expect ...int) (*http.Response, error) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(input); err != nil {
-		return errors.Wrap(err, "failed to serialize request body")
+		return nil, errors.Wrap(err, "failed to serialize request body")
 	}
 	req, err := http.NewRequest(http.MethodPut, u, &buf)
 	if err != nil {
-		return errors.Wrap(err, "failed to build request")
+		return nil, errors.Wrap(err, "failed to build request")
 	}
 
 	if err := c.sign(req); err != nil {
-		return errors.Wrap(err, "failed to sign HTTP request")
+		return nil, errors.Wrap(err, "failed to sign HTTP request")
 	}
 
 	response, err := c.cl.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "failed to send request")
+		return nil, errors.Wrap(err, "failed to send request")
 	}
 
-	return c.process(response, output, expect...)
+	return nil, c.process(response, output, expect...)
 }
 
-func (c *httpClient) get(u string, query url.Values, output interface{}, expect ...int) error {
+func (c *httpClient) get(u string, query url.Values, output interface{}, expect ...int) (*http.Response, error) {
 	if len(query) > 0 {
 		u = fmt.Sprintf("%s?%s", u, query.Encode())
 	}
 
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to create new HTTP request")
+		return nil, errors.Wrap(err, "failed to create new HTTP request")
 	}
 
 	if err := c.sign(req); err != nil {
-		return errors.Wrap(err, "failed to sign HTTP request")
+		return nil, errors.Wrap(err, "failed to sign HTTP request")
 	}
 
 	response, err := c.cl.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "failed to send request")
+		return nil, errors.Wrap(err, "failed to send request")
 	}
 
-	return c.process(response, output, expect...)
+	return response, c.process(response, output, expect...)
 }
 
-func (c *httpClient) delete(u string, query url.Values, output interface{}, expect ...int) error {
+func (c *httpClient) delete(u string, query url.Values, output interface{}, expect ...int) (*http.Response, error) {
 	if len(query) > 0 {
 		u = fmt.Sprintf("%s?%s", u, query.Encode())
 	}
 	req, err := http.NewRequest(http.MethodDelete, u, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to build request")
+		return nil, errors.Wrap(err, "failed to build request")
 	}
 
 	if err := c.sign(req); err != nil {
-		return errors.Wrap(err, "failed to sign HTTP request")
+		return nil, errors.Wrap(err, "failed to sign HTTP request")
 	}
 
 	response, err := c.cl.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "failed to send request")
+		return nil, errors.Wrap(err, "failed to send request")
 	}
 
-	return c.process(response, output, expect...)
+	return response, c.process(response, output, expect...)
 }

--- a/client/phonebook.go
+++ b/client/phonebook.go
@@ -15,7 +15,7 @@ type httpPhonebook struct {
 
 func (p *httpPhonebook) Create(user phonebook.User) (schema.ID, error) {
 	var out phonebook.User
-	if err := p.post(p.url("users"), user, &out); err != nil {
+	if _, err := p.post(p.url("users"), user, &out); err != nil {
 		return 0, err
 	}
 
@@ -32,13 +32,13 @@ func (p *httpPhonebook) List(name, email string, page *Pager) (output []phoneboo
 		query.Set("email", email)
 	}
 
-	err = p.get(p.url("users"), query, &output, http.StatusOK)
+	_, err = p.get(p.url("users"), query, &output, http.StatusOK)
 
 	return
 }
 
 func (p *httpPhonebook) Get(id schema.ID) (user phonebook.User, err error) {
-	err = p.get(p.url("users", fmt.Sprint(id)), nil, &user, http.StatusOK)
+	_, err = p.get(p.url("users", fmt.Sprint(id)), nil, &user, http.StatusOK)
 	return
 }
 
@@ -55,7 +55,7 @@ func (p *httpPhonebook) Validate(id schema.ID, message, signature string) (bool,
 		V bool `json:"is_valid"`
 	}
 
-	err := p.post(p.url("users", fmt.Sprint(id), "validate"), input, &output, http.StatusOK)
+	_, err := p.post(p.url("users", fmt.Sprint(id), "validate"), input, &output, http.StatusOK)
 	if err != nil {
 		return false, err
 	}

--- a/client/workloads.go
+++ b/client/workloads.go
@@ -131,6 +131,8 @@ func (wl *intermediateWL) Workload() (result workloads.ReservationWorkload, err 
 			return result, err
 		}
 		result.Content = o
+	case workloads.WorkloadTypeNOOP:
+		//do nothing so result.Content will be nil
 	default:
 		return result, fmt.Errorf("unknown workload type")
 	}

--- a/models/generated/workloads/reservation.go
+++ b/models/generated/workloads/reservation.go
@@ -138,9 +138,6 @@ const (
 	WorkloadTypeSubDomain
 	WorkloadTypeDomainDelegate
 	WorkloadTypeGateway4To6
-	// WorkloadTypeNOOP a NOOP reservation is a reservation that does nothing
-	// but used mainly to tell the node about the next poll cursor
-	WorkloadTypeNOOP
 )
 
 // WorkloadTypes is a map of all the supported workload type
@@ -155,7 +152,6 @@ var WorkloadTypes = map[WorkloadTypeEnum]string{
 	WorkloadTypeSubDomain:      "subdomain",
 	WorkloadTypeDomainDelegate: "domain-delegate",
 	WorkloadTypeGateway4To6:    "gateway4to6",
-	WorkloadTypeNOOP:           "noop",
 }
 
 func (e WorkloadTypeEnum) String() string {

--- a/models/generated/workloads/reservation.go
+++ b/models/generated/workloads/reservation.go
@@ -138,6 +138,9 @@ const (
 	WorkloadTypeSubDomain
 	WorkloadTypeDomainDelegate
 	WorkloadTypeGateway4To6
+	// WorkloadTypeNOOP a NOOP reservation is a reservation that does nothing
+	// but used mainly to tell the node about the next poll cursor
+	WorkloadTypeNOOP
 )
 
 // WorkloadTypes is a map of all the supported workload type
@@ -152,6 +155,7 @@ var WorkloadTypes = map[WorkloadTypeEnum]string{
 	WorkloadTypeSubDomain:      "subdomain",
 	WorkloadTypeDomainDelegate: "domain-delegate",
 	WorkloadTypeGateway4To6:    "gateway4to6",
+	WorkloadTypeNOOP:           "noop",
 }
 
 func (e WorkloadTypeEnum) String() string {

--- a/models/id.go
+++ b/models/id.go
@@ -49,3 +49,20 @@ func MustID(ctx context.Context, db *mongo.Database, collection string) schema.I
 
 	return id
 }
+
+// LastID get the last max value in the collection
+func LastID(ctx context.Context, db *mongo.Database, collection string) (schema.ID, error) {
+	result := db.Collection(Counters).FindOne(ctx, bson.M{"_id": collection})
+
+	if result.Err() == mongo.ErrNoDocuments {
+		return 0, nil
+	} else if result.Err() != nil {
+		return 0, result.Err()
+	}
+
+	var value struct {
+		Sequence schema.ID `bson:"sequence"`
+	}
+	err := result.Decode(&value)
+	return value.Sequence, err
+}

--- a/pkg/workloads/reservation.go
+++ b/pkg/workloads/reservation.go
@@ -458,6 +458,12 @@ func (a *API) workloads(r *http.Request) (interface{}, mw.Response) {
 		return nil, mw.BadRequest(err)
 	}
 
+	// store last reservation ID
+	lastID, err := types.ReservationLastID(r.Context(), db)
+	if err != nil {
+		return nil, mw.Error(err)
+	}
+
 	filter := types.ReservationFilter{}.WithIDGE(from)
 	filter = filter.WithNodeID(nodeID)
 
@@ -496,6 +502,10 @@ func (a *API) workloads(r *http.Request) (interface{}, mw.Response) {
 		if len(workloads) >= maxPageSize {
 			break
 		}
+	}
+
+	if len(workloads) == 0 {
+		workloads = append(workloads, types.NOOPWorkload(nodeID, lastID))
 	}
 
 	return workloads, nil

--- a/pkg/workloads/reservation.go
+++ b/pkg/workloads/reservation.go
@@ -504,11 +504,7 @@ func (a *API) workloads(r *http.Request) (interface{}, mw.Response) {
 		}
 	}
 
-	if len(workloads) == 0 {
-		workloads = append(workloads, types.NOOPWorkload(nodeID, lastID))
-	}
-
-	return workloads, nil
+	return workloads, mw.Ok().WithHeader("x-last-id", fmt.Sprint(lastID))
 }
 
 func (a *API) workloadGet(r *http.Request) (interface{}, mw.Response) {

--- a/pkg/workloads/types/reservation.go
+++ b/pkg/workloads/types/reservation.go
@@ -718,15 +718,3 @@ func ResultPush(ctx context.Context, db *mongo.Database, id schema.ID, result Re
 
 	return err
 }
-
-// NOOPWorkload creates a noop workload
-func NOOPWorkload(nodeID string, id schema.ID) Workload {
-	return Workload{
-		NodeID: nodeID,
-		ReservationWorkload: generated.ReservationWorkload{
-			WorkloadId: fmt.Sprintf("%d-0", id),
-			Type:       generated.WorkloadTypeNOOP,
-			Created:    schema.Date{Time: time.Now()},
-		},
-	}
-}

--- a/pkg/workloads/types/reservation.go
+++ b/pkg/workloads/types/reservation.go
@@ -560,6 +560,11 @@ func ReservationCreate(ctx context.Context, db *mongo.Database, r Reservation) (
 	return id, nil
 }
 
+// ReservationLastID get the current last ID number in the reservations collection
+func ReservationLastID(ctx context.Context, db *mongo.Database) (schema.ID, error) {
+	return models.LastID(ctx, db, ReservationCollection)
+}
+
 // ReservationSetNextAction update the reservation next action in db
 func ReservationSetNextAction(ctx context.Context, db *mongo.Database, id schema.ID, action generated.NextActionEnum) error {
 	var filter ReservationFilter
@@ -712,4 +717,16 @@ func ResultPush(ctx context.Context, db *mongo.Database, id schema.ID, result Re
 	})
 
 	return err
+}
+
+// NOOPWorkload creates a noop workload
+func NOOPWorkload(nodeID string, id schema.ID) Workload {
+	return Workload{
+		NodeID: nodeID,
+		ReservationWorkload: generated.ReservationWorkload{
+			WorkloadId: fmt.Sprintf("%d-0", id),
+			Type:       generated.WorkloadTypeNOOP,
+			Created:    schema.Date{Time: time.Now()},
+		},
+	}
 }


### PR DESCRIPTION
If no available reservations for the node, force it to sync to last poll cursor by sending a NOOP workload