### PR TITLE
change definition of freeTFT

### DIFF
--- a/pkg/directory/types/gateway.go
+++ b/pkg/directory/types/gateway.go
@@ -70,6 +70,15 @@ func (f GatewayFilter) WithGWID(id string) GatewayFilter {
 	return append(f, bson.E{Key: "node_id", Value: id})
 }
 
+// WithGWIDs list gateways which ndoe_id is in ids slice
+func (f GatewayFilter) WithGWIDs(ids []string) GatewayFilter {
+	a := make(bson.A, len(ids))
+	for i := range ids {
+		a[i] = ids[i]
+	}
+	return append(f, bson.E{Key: "node_id", Value: bson.M{"$in": a}})
+}
+
 // WithLocation search the nodes that are located in country and or city
 func (f GatewayFilter) WithLocation(country, city string) GatewayFilter {
 	if country != "" {
@@ -80,6 +89,11 @@ func (f GatewayFilter) WithLocation(country, city string) GatewayFilter {
 	}
 
 	return f
+}
+
+// WithFreeToUse search the nodes that free_to_use value is equal to freeToUse
+func (f GatewayFilter) WithFreeToUse(freeToUse bool) GatewayFilter {
+	return append(f, bson.E{Key: "free_to_use", Value: freeToUse})
 }
 
 // Find run the filter and return a cursor result

--- a/pkg/directory/types/node.go
+++ b/pkg/directory/types/node.go
@@ -75,6 +75,15 @@ func (f NodeFilter) WithNodeID(id string) NodeFilter {
 	return append(f, bson.E{Key: "node_id", Value: id})
 }
 
+// WithNodeIDs list gateways which node_id is in ids slice
+func (f NodeFilter) WithNodeIDs(ids []string) NodeFilter {
+	a := make(bson.A, len(ids))
+	for i := range ids {
+		a[i] = ids[i]
+	}
+	return append(f, bson.E{Key: "node_id", Value: bson.M{"$in": a}})
+}
+
 // WithFarmID search nodes with given farmID
 func (f NodeFilter) WithFarmID(id schema.ID) NodeFilter {
 	return append(f, bson.E{Key: "farm_id", Value: id})
@@ -106,6 +115,11 @@ func (f NodeFilter) WithLocation(country, city string) NodeFilter {
 	}
 
 	return f
+}
+
+// WithFreeToUse search the nodes that free_to_use value is equal to freeToUse
+func (f NodeFilter) WithFreeToUse(freeToUse bool) NodeFilter {
+	return append(f, bson.E{Key: "free_to_use", Value: freeToUse})
 }
 
 // Find run the filter and return a cursor result


### PR DESCRIPTION
After this change a node marked as free to use means that the node also
accept freeFTF in addition to all the other supported currency of the
farmer.

This change from the current definition which was the node can only be
paid with FreeTFT.

fixes #50