### PR TITLE
tfuser: fix network add-node not updating schema with network resources

### DIFF
--- a/cmds/tfuser/cmds_network.go
+++ b/cmds/tfuser/cmds_network.go
@@ -91,17 +91,21 @@ func cmdsAddNode(c *cli.Context) error {
 		return err
 	}
 
+	fmt.Println(network)
+
 	network, err = network.AddNode(nodeID, subnet, port, forceHidden)
 	if err != nil {
 		return errors.Wrapf(err, "failed to add a node to the network %s", network.Name)
 	}
 
-	f, err = os.Open(networkSchema)
+	fmt.Println(network)
+
+	nf, err := os.Create(networkSchema + ".new")
 	if err != nil {
 		return errors.Wrap(err, "failed to open networks schema")
 	}
 
-	return network.Save(f)
+	return network.Save(nf)
 }
 
 func cmdsAddAccess(c *cli.Context) error {

--- a/cmds/tfuser/cmds_network.go
+++ b/cmds/tfuser/cmds_network.go
@@ -91,16 +91,12 @@ func cmdsAddNode(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Println(network)
-
 	network, err = network.AddNode(nodeID, subnet, port, forceHidden)
 	if err != nil {
 		return errors.Wrapf(err, "failed to add a node to the network %s", network.Name)
 	}
 
-	fmt.Println(network)
-
-	nf, err := os.Create(networkSchema + ".new")
+	nf, err := os.Create(networkSchema)
 	if err != nil {
 		return errors.Wrap(err, "failed to open networks schema")
 	}

--- a/cmds/tfuser/main.go
+++ b/cmds/tfuser/main.go
@@ -48,6 +48,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "seed",
 			Usage:  "path to the file container the seed of the user private key",
+			Value:  "user.seed",
 			EnvVar: "SEED_PATH",
 		},
 	}

--- a/provision/builders/networkBuilder.go
+++ b/provision/builders/networkBuilder.go
@@ -92,11 +92,7 @@ func LoadNetworkBuilder(reader io.Reader, explorer *client.Client) (*NetworkBuil
 
 // Save saves the network builder to an IO.Writer
 func (n *NetworkBuilder) Save(writer io.Writer) error {
-	err := json.NewEncoder(writer).Encode(n.Network)
-	if err != nil {
-		return err
-	}
-	return err
+	return json.NewEncoder(writer).Encode(n.Network)
 }
 
 // Build returns the network

--- a/provision/builders/networkBuilder.go
+++ b/provision/builders/networkBuilder.go
@@ -73,7 +73,7 @@ func LoadNetworkBuilder(reader io.Reader, explorer *client.Client) (*NetworkBuil
 
 	err := json.NewDecoder(reader).Decode(&network)
 	if err != nil {
-		return &NetworkBuilder{}, err
+		return nil, err
 	}
 
 	networkBuilder := &NetworkBuilder{

--- a/provision/builders/networkBuilder.go
+++ b/provision/builders/networkBuilder.go
@@ -184,6 +184,7 @@ func (n *NetworkBuilder) AddNode(nodeID string, subnet string, port uint, forceH
 	}
 
 	n.NetResources = append(n.NetResources, nr)
+	n.Network.NetworkResources = append(n.Network.NetworkResources, nr.NetworkNetResource)
 
 	if err = n.generatePeers(); err != nil {
 		return n, errors.Wrap(err, "failed to generate peers")


### PR DESCRIPTION
When doing `tfuser network --schema xxx add-node` the schema was not updated at all. First error was a `bad file descriptor` and second error was network resource not present at all on dump.

This pull request fix that, but maybe not the best way expected. Review welcome.