### PR TITLE
Fix unknown workload increment in client

### DIFF
--- a/client/workloads.go
+++ b/client/workloads.go
@@ -175,8 +175,16 @@ func (w *httpWorkloads) Workloads(nodeID string, from uint64) ([]workloads.Reser
 	for _, i := range list {
 		wl, err := i.Workload()
 		if err != nil {
+			// skipping unknown workloads
+			if err == ErrUnknownWorkload {
+				continue
+			}
+
+			// something else went wrong
 			return nil, lastID, err
 		}
+
+		// forward this workload to caller
 		results = append(results, wl)
 	}
 

--- a/client/workloads.go
+++ b/client/workloads.go
@@ -13,6 +13,8 @@ import (
 	"github.com/threefoldtech/tfexplorer/schema"
 )
 
+var ErrUnknownWorkload = errors.New("unknown workload type")
+
 type httpWorkloads struct {
 	*httpClient
 }
@@ -138,7 +140,7 @@ func (wl *intermediateWL) Workload() (result workloads.ReservationWorkload, err 
 		}
 		result.Content = o
 	default:
-		return result, fmt.Errorf("unknown workload type")
+		return result, ErrUnknownWorkload
 	}
 
 	return

--- a/client/workloads.go
+++ b/client/workloads.go
@@ -13,6 +13,7 @@ import (
 	"github.com/threefoldtech/tfexplorer/schema"
 )
 
+// ErrUnknownWorkload define error when an unknown workload is found from reservation
 var ErrUnknownWorkload = errors.New("unknown workload type")
 
 type httpWorkloads struct {

--- a/client/workloads.go
+++ b/client/workloads.go
@@ -13,8 +13,8 @@ import (
 	"github.com/threefoldtech/tfexplorer/schema"
 )
 
-// ErrUnknownWorkload define error when an unknown workload is found from reservation
-var ErrUnknownWorkload = errors.New("unknown workload type")
+// errUnknownWorkload define error when an unknown workload is found from reservation
+var errUnknownWorkload = errors.New("unknown workload type")
 
 type httpWorkloads struct {
 	*httpClient
@@ -141,7 +141,7 @@ func (wl *intermediateWL) Workload() (result workloads.ReservationWorkload, err 
 		}
 		result.Content = o
 	default:
-		return result, ErrUnknownWorkload
+		return result, errUnknownWorkload
 	}
 
 	return
@@ -177,7 +177,7 @@ func (w *httpWorkloads) Workloads(nodeID string, from uint64) ([]workloads.Reser
 		wl, err := i.Workload()
 		if err != nil {
 			// skipping unknown workloads
-			if err == ErrUnknownWorkload {
+			if err == errUnknownWorkload {
 				continue
 			}
 

--- a/client/workloads_test.go
+++ b/client/workloads_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/threefoldtech/tfexplorer/models/generated/workloads"
+)
+
+func TestIntermediateWLWorkloadsUnknownType(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		iwl  intermediateWL
+		err  error
+	}{
+		{
+			name: "container",
+			iwl: intermediateWL{
+				ReservationWorkload: workloads.ReservationWorkload{
+					Type: workloads.WorkloadTypeContainer,
+				},
+				Content: func(i workloads.Container) []byte {
+					b, err := json.Marshal(i)
+					require.NoError(t, err)
+					return b
+				}(workloads.Container{WorkloadId: 1}),
+			},
+			err: nil,
+		},
+		{
+			name: "unknown",
+			iwl: intermediateWL{
+				ReservationWorkload: workloads.ReservationWorkload{
+					Type: 12,
+				},
+			},
+			err: errUnknownWorkload,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+
+			_, err := tc.iwl.Workload()
+			if tc.err != nil {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, errUnknownWorkload))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+}

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmeka
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -225,7 +226,9 @@ github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/V
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c h1:RBUpb2b14UnmRHNd2uHz20ZHLDK+SW5Us/vWF5IHRaY=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e h1:BWhy2j3IXJhjCbC68FptL43tDKIq8FladmaTs3Xs7Z8=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
+github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.3.0/go.mod h1:d+q1s/xVJxZGKWwC/6UfPIF33J+G1Tq4GYv9Y+Tg/EU=
@@ -287,6 +290,7 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 h1:ECW73yc9MY7935nNYXUkK7Dz17YuSUI9yqRqYS8aBww=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
+github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=

--- a/go.sum
+++ b/go.sum
@@ -389,10 +389,12 @@ github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -519,7 +521,6 @@ github.com/threefoldtech/zos v0.2.4-rc2 h1:/0G7ETVtqfXpl/ufqSI0sHmtKRUwTKr90lnNn
 github.com/threefoldtech/zos v0.2.4-rc2/go.mod h1:7A2oflcmSVsHFC4slOcydWgJyFBMFMH9wsaTRv+CnTA=
 github.com/threefoldtech/zos v0.2.4 h1:W9QhzJqU+dwxLOa/AH4uXnTPtYhcMaNHTCw888yvSHo=
 github.com/threefoldtech/zos v0.2.4/go.mod h1:B1SeNF7YWpDEUFX4dgAXImHO49HB5zDuD+q3YRY5xvA=
-github.com/threefoldtech/zos v0.3.0 h1:ldxgWmMPAsBJ7w8prLk0iUFYG6J2Lkh0eQJ16dJa0QY=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tyler-smith/go-bip39 v0.0.0-20180618194314-52158e4697b8/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
@@ -569,6 +570,7 @@ github.com/zaibon/httpsig v0.0.0-20200401133919-ea9cb57b0946 h1:s12kADbuUVEJkYxq
 github.com/zaibon/httpsig v0.0.0-20200401133919-ea9cb57b0946/go.mod h1:T2e9wAAQHKLB08ONx+0xxxrlAfUnRbwLOpO0WodNbQ4=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
+go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=


### PR DESCRIPTION
Skipping unknown workload id when iterating over the list and not returning an error to the caller. This fix the increment issue. On theses logs, we can see next is incremented, one unsupported workload was added.

```
[+] provisiond: 2020-06-02T08:17:28Z info Polling for reservations next=18
[+] provisiond: 2020-06-02T08:17:38Z info Polling for reservations next=18
[+] provisiond: 2020-06-02T08:17:38Z info check for expired reservation
[+] provisiond: 2020-06-02T08:17:48Z info Polling for reservations next=18
[+] provisiond: 2020-06-02T08:17:58Z info Polling for reservations next=19
[+] provisiond: 2020-06-02T08:17:58Z info check for expired reservation
[+] provisiond: 2020-06-02T08:18:08Z info Polling for reservations next=19
[+] provisiond: 2020-06-02T08:18:18Z info Polling for reservations next=19
```

More debug message should be added but log is not imported anyway, I didn't added it.

This fixes https://github.com/threefoldtech/zos/issues/802