### PR TITLE
add yggdrasill range in the list of private network

### DIFF
--- a/provision/builders/networkBuilder.go
+++ b/provision/builders/networkBuilder.go
@@ -702,6 +702,7 @@ func isPrivateIP(ip net.IP) bool {
 		"::1/128",        // IPv6 loopback
 		"fe80::/10",      // IPv6 link-local
 		"fc00::/7",       // IPv6 unique local addr
+		"200::/7",        // yggdrasil network
 	} {
 		_, block, err := net.ParseCIDR(cidr)
 		if err != nil {


### PR DESCRIPTION
this is to avoid the network generation to use yggdrasil IP address as
public endpoint