### PR TITLE
Disable disk-type selection on tfuser

### DIFF
--- a/cmds/tfuser/cmds_container.go
+++ b/cmds/tfuser/cmds_container.go
@@ -29,12 +29,7 @@ func generateContainer(c *cli.Context) error {
 		Cpu:      c.Int64("cpu"),
 		Memory:   c.Int64("memory"),
 		DiskSize: c.Uint64("disk-size"),
-	}
-	switch strings.ToLower(c.String("disk-type")) {
-	case "hdd":
-		cap.DiskType = workloads.DiskTypeHDD
-	case "ssd":
-		cap.DiskType = workloads.DiskTypeSSD
+		DiskType: workloads.DiskTypeSSD,
 	}
 
 	var sts []workloads.StatsAggregator

--- a/cmds/tfuser/main.go
+++ b/cmds/tfuser/main.go
@@ -323,10 +323,6 @@ func main() {
 							Name:  "root-size",
 							Usage: "Size of the root fs",
 						},
-						cli.StringFlag{
-							Name:  "root-type",
-							Usage: "type of disk to use for the root fs",
-						},
 						cli.BoolFlag{
 							Name:  "public6",
 							Usage: "when enabled, the container will have a public IPv6 interface",


### PR DESCRIPTION
Recent changes prevent container to be executed on HDD, only SSD are
allowed as disk-type. Disable user selection and force disk to be set as
SSD by default.