### PR TITLE
Fix #132: Ensure right cloud formula is used

### DIFF
--- a/pkg/capacity/conversion.go
+++ b/pkg/capacity/conversion.go
@@ -8,8 +8,8 @@ import (
 
 // CloudUnitsFromResourceUnits converts an amount of RSU to the Cloud unit representation
 func CloudUnitsFromResourceUnits(rsu workloads.RSU) (float64, float64) {
-	cu := math.Min(float64(rsu.CRU)*4, (rsu.MRU-1)/4)
-	su := float64(rsu.HRU)/1000/1.2 + float64(rsu.SRU)/100/1.2
+	cu := math.Min(float64(rsu.CRU)*2, (rsu.MRU-1)/4)
+	su := (float64(rsu.HRU)/1000 + float64(rsu.SRU)/100/2) / 1.2
 
 	return cu, su
 }

--- a/pkg/capacity/conversion_test.go
+++ b/pkg/capacity/conversion_test.go
@@ -39,6 +39,52 @@ func TestCloudUnitsFromResourceUnits(t *testing.T) {
 			cu: 1.75,
 			su: 0,
 		},
+		{
+			rsu: workloads.RSU{
+				CRU: 4,
+				MRU: 64,
+			},
+			cu: 8,
+			su: 0,
+		},
+		{
+			rsu: workloads.RSU{
+				CRU: 4,
+				MRU: 32,
+			},
+			cu: 7.75,
+			su: 0,
+		},
+		{
+			rsu: workloads.RSU{
+				SRU: 120,
+				HRU: 1200,
+			},
+			cu: -0.25,
+			su: 1.5,
+		},
+		{
+			rsu: workloads.RSU{
+				SRU: 40,
+				HRU: 1000,
+			},
+			cu: -0.25,
+			su: 1,
+		},
+		{
+			rsu: workloads.RSU{
+				SRU: 1200,
+			},
+			cu: -0.25,
+			su: 5,
+		},
+		{
+			rsu: workloads.RSU{
+				HRU: 12000,
+			},
+			cu: -0.25,
+			su: 10,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v", tt.rsu), func(t *testing.T) {


### PR DESCRIPTION
Compute cloud units as described on
https://wiki.threefold.io/#/cloud_units. There is also another
computation for cloud units in the code, which uses a legacy formula.
This code path is however no longer used and will be removed in a future
cleanup, most likely as part of #121