### PR TITLE
change how delete and provision signature are accepted and verified

### DIFF
--- a/models/generated/workloads/workload.go
+++ b/models/generated/workloads/workload.go
@@ -330,18 +330,30 @@ func (i *ReservationInfo) SetDescription(description string) {
 }
 
 func (i *ReservationInfo) SetSigningRequestProvision(request SigningRequest) {
+	if request.Signers == nil {
+		request.Signers = make([]int64, 0)
+	}
 	i.SigningRequestProvision = request
 }
 
 func (i *ReservationInfo) SetSigningRequestDelete(request SigningRequest) {
+	if request.Signers == nil {
+		request.Signers = make([]int64, 0)
+	}
 	i.SigningRequestDelete = request
 }
 
 func (i *ReservationInfo) SetSignaturesProvision(signatures []SigningSignature) {
+	if signatures == nil {
+		signatures = make([]SigningSignature, 0)
+	}
 	i.SignaturesProvision = signatures
 }
 
 func (i *ReservationInfo) SetSignaturesDelete(signatures []SigningSignature) {
+	if signatures == nil {
+		signatures = make([]SigningSignature, 0)
+	}
 	i.SignaturesDelete = signatures
 }
 

--- a/pkg/workloads/reservation_test.go
+++ b/pkg/workloads/reservation_test.go
@@ -1,0 +1,74 @@
+package workloads
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/threefoldtech/tfexplorer/models/generated/workloads"
+)
+
+func Test_userCanSign(t *testing.T) {
+	type args struct {
+		userTid    int64
+		req        workloads.SigningRequest
+		signatures []workloads.SigningSignature
+	}
+	tests := []struct {
+		name string
+		args args
+		err  bool
+	}{
+		{
+			name: "user_required_no_signature",
+			args: args{
+				userTid: 1,
+				req: workloads.SigningRequest{
+					QuorumMin: 1,
+					Signers:   []int64{1},
+				},
+				signatures: []workloads.SigningSignature{},
+			},
+			err: false,
+		},
+		{
+			name: "user_required_already_signed",
+			args: args{
+				userTid: 1,
+				req: workloads.SigningRequest{
+					QuorumMin: 1,
+					Signers:   []int64{1},
+				},
+				signatures: []workloads.SigningSignature{
+					{
+						Tid:       2,
+						Signature: "foobar",
+					},
+					{
+						Tid:       1,
+						Signature: "foobar",
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "user_not_required",
+			args: args{
+				userTid: 1,
+				req: workloads.SigningRequest{
+					QuorumMin: 1,
+					Signers:   []int64{2},
+				},
+				signatures: []workloads.SigningSignature{},
+			},
+			err: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := userCanSign(tt.args.userTid, tt.args.req, tt.args.signatures)
+			assert.Equal(t, tt.err, err != nil)
+		})
+	}
+}

--- a/pkg/workloads/types/pipeline.go
+++ b/pkg/workloads/types/pipeline.go
@@ -32,25 +32,8 @@ func (p *Pipeline) checkProvisionSignatures() bool {
 		return true
 	}
 
-	in := func(i int64, l []int64) bool {
-		for _, x := range l {
-			if x == i {
-				return true
-			}
-		}
-		return false
-	}
-
-	signatures := p.r.SignaturesProvision
-	var count int64
-	for _, signature := range signatures {
-		if !in(signature.Tid, request.Signers) {
-			continue
-		}
-		count++
-	}
-
-	return count >= request.QuorumMin
+	signers := countSignatures(p.r.SignaturesProvision, request)
+	return int64(signers) >= request.QuorumMin
 }
 
 func (p *Pipeline) checkDeleteSignatures() bool {
@@ -65,25 +48,8 @@ func (p *Pipeline) checkDeleteSignatures() bool {
 		return false
 	}
 
-	in := func(i int64, l []int64) bool {
-		for _, x := range l {
-			if x == i {
-				return true
-			}
-		}
-		return false
-	}
-
-	signatures := p.r.SignaturesDelete
-	var count int64
-	for _, signature := range signatures {
-		if !in(signature.Tid, request.Signers) {
-			continue
-		}
-		count++
-	}
-
-	return count >= request.QuorumMin
+	signers := countSignatures(p.r.SignaturesDelete, request)
+	return int64(signers) >= request.QuorumMin
 }
 
 // Next gets new modified reservation, and true if the reservation has changed from the input

--- a/pkg/workloads/types/reservation.go
+++ b/pkg/workloads/types/reservation.go
@@ -326,19 +326,20 @@ func (r *Reservation) Workloads(nodeID string) []WorkloaderType {
 
 	data := &r.DataReservation
 
-	newWrkl := func(w workloads.Workloader, id schema.ID, user int64, na workloads.NextActionEnum, epoch schema.Date, meta string, provisionRequest workloads.SigningRequest, deleteRequest workloads.SigningRequest, result *Result) WorkloaderType {
+	newWrkl := func(w workloads.Workloader, workloadID int64, r *Reservation) WorkloaderType {
 		workload := WorkloaderType{Workloader: w}
-		workload.SetCustomerTid(user)
-		workload.SetNextAction(na)
-		workload.SetID(id)
-		workload.SetEpoch(epoch)
-		workload.SetMetadata(meta)
+		workload.SetCustomerTid(r.CustomerTid)
+		workload.SetNextAction(r.NextAction)
+		workload.SetDescription(r.DataReservation.Description)
+		workload.SetEpoch(r.Epoch)
+		workload.SetID(r.ID)
+		workload.SetMetadata(r.Metadata)
+		result := r.ResultOf(fmt.Sprintf("%d-%d", r.ID, workloadID))
 		if result != nil {
 			workload.SetResult(workloads.Result(*result))
 		}
-		workload.SetSigningRequestProvision(provisionRequest)
-		workload.SetSigningRequestDelete(deleteRequest)
-
+		workload.SetSigningRequestProvision(r.DataReservation.SigningRequestProvision)
+		workload.SetSigningRequestDelete(r.DataReservation.SigningRequestDelete)
 		return workload
 	}
 
@@ -348,18 +349,8 @@ func (r *Reservation) Workloads(nodeID string) []WorkloaderType {
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadId)
 		wl.WorkloadType = generated.WorkloadTypeContainer
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 
 	for i := range data.Volumes {
@@ -367,144 +358,64 @@ func (r *Reservation) Workloads(nodeID string) []WorkloaderType {
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeVolume
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.Zdbs {
 		wl := data.Zdbs[i]
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeZDB
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.Kubernetes {
 		wl := data.Kubernetes[i]
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeKubernetes
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.Proxies {
 		wl := data.Proxies[i]
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeProxy
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.ReverseProxy {
 		wl := data.ReverseProxy[i]
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeReverseProxy
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.Subdomains {
 		wl := data.Subdomains[i]
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeSubDomain
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.DomainDelegates {
 		wl := data.DomainDelegates[i]
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeDomainDelegate
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.Gateway4To6s {
 		wl := data.Gateway4To6s[i]
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeGateway4To6
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 	for i := range data.Networks {
 		wl := data.Networks[i]
@@ -515,18 +426,8 @@ func (r *Reservation) Workloads(nodeID string) []WorkloaderType {
 				continue
 			}
 
-			uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 			nr.WorkloadType = generated.WorkloadTypeNetworkResource
-			wrklds = append(wrklds, newWrkl(
-				&nr,
-				r.ID,
-				r.CustomerTid,
-				r.NextAction,
-				r.Epoch,
-				r.Metadata,
-				r.DataReservation.SigningRequestProvision,
-				r.DataReservation.SigningRequestDelete,
-				r.ResultOf(uwid)))
+			wrklds = append(wrklds, newWrkl(&nr, wl.WorkloadId, r))
 		}
 	}
 	for i := range data.NetworkResources {
@@ -534,18 +435,8 @@ func (r *Reservation) Workloads(nodeID string) []WorkloaderType {
 		if len(nodeID) > 0 && wl.NodeId != nodeID {
 			continue
 		}
-		uwid := fmt.Sprintf("%d-%d", r.ID, wl.WorkloadID())
 		wl.WorkloadType = generated.WorkloadTypeNetworkResource
-		wrklds = append(wrklds, newWrkl(
-			&wl,
-			r.ID,
-			r.CustomerTid,
-			r.NextAction,
-			r.Epoch,
-			r.Metadata,
-			r.DataReservation.SigningRequestProvision,
-			r.DataReservation.SigningRequestDelete,
-			r.ResultOf(uwid)))
+		wrklds = append(wrklds, newWrkl(&wl, wl.WorkloadId, r))
 	}
 
 	return wrklds

--- a/pkg/workloads/types/reservation.go
+++ b/pkg/workloads/types/reservation.go
@@ -701,31 +701,17 @@ const (
 
 //ReservationPushSignature push signature to reservation
 func ReservationPushSignature(ctx context.Context, db *mongo.Database, id schema.ID, mode SignatureMode, signature generated.SigningSignature) error {
-
+	// this function just push the signature to the reservation array
+	// there are not other checks involved here. So before calling this function
+	// we need to ensure the signature has the rights to be pushed
 	var filter ReservationFilter
 	filter = filter.WithID(id)
 	col := db.Collection(ReservationCollection)
-	// NOTE: this should be a transaction not a bulk write
-	// but i had so many issues with transaction, and i couldn't
-	// get it to work. so I used bulk write in place instead
-	// until we figure this issue out.
-	// Note, the reason we don't just use addToSet is the signature
-	// object always have the current 'time' which means it's a different
-	// value than the one in the document even if it has same user id.
-	_, err := col.BulkWrite(ctx, []mongo.WriteModel{
-		mongo.NewUpdateOneModel().SetFilter(filter).SetUpdate(
-			bson.M{
-				"$pull": bson.M{
-					string(mode): bson.M{"tid": signature.Tid},
-				},
-			}),
-		mongo.NewUpdateOneModel().SetFilter(filter).SetUpdate(
-			bson.M{
-				"$addToSet": bson.M{
-					string(mode): signature,
-				},
-			}),
-	}, options.BulkWrite().SetOrdered(true))
+	_, err := col.UpdateOne(ctx, filter, bson.M{
+		"$push": bson.M{
+			string(mode): signature,
+		},
+	})
 
 	return err
 }

--- a/pkg/workloads/types/signature.go
+++ b/pkg/workloads/types/signature.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	generated "github.com/threefoldtech/tfexplorer/models/generated/workloads"
+)
+
+func countSignatures(signatures []generated.SigningSignature, req generated.SigningRequest) int {
+	in := func(i int64, l []int64) bool {
+		for _, x := range l {
+			if x == i {
+				return true
+			}
+		}
+		return false
+	}
+
+	signers := map[int64]interface{}{}
+	for _, signature := range signatures {
+		if !in(signature.Tid, req.Signers) {
+			continue
+		}
+		_, exists := signers[signature.Tid]
+		if !exists {
+			signers[signature.Tid] = struct{}{}
+		}
+	}
+
+	return len(signers)
+}

--- a/pkg/workloads/types/signature_test.go
+++ b/pkg/workloads/types/signature_test.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	generated "github.com/threefoldtech/tfexplorer/models/generated/workloads"
+)
+
+func Test_countSignatures(t *testing.T) {
+	type args struct {
+		signatures []generated.SigningSignature
+		req        generated.SigningRequest
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "included",
+			args: args{
+				signatures: []generated.SigningSignature{
+					{
+						Tid: 1,
+					},
+				},
+				req: generated.SigningRequest{
+					Signers: []int64{1},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "not_required",
+			args: args{
+				signatures: []generated.SigningSignature{
+					{
+						Tid: 1,
+					},
+				},
+				req: generated.SigningRequest{
+					Signers: []int64{2},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "multiple",
+			args: args{
+				signatures: []generated.SigningSignature{
+					{Tid: 1},
+					{Tid: 2},
+					{Tid: 3},
+				},
+				req: generated.SigningRequest{
+					Signers: []int64{1, 3},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "empty",
+			args: args{
+				signatures: []generated.SigningSignature{},
+				req: generated.SigningRequest{
+					Signers: []int64{1},
+				},
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countSignatures(tt.args.signatures, tt.args.req)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/workloads/types/workload.go
+++ b/pkg/workloads/types/workload.go
@@ -363,6 +363,20 @@ func WorkloadCreate(ctx context.Context, db *mongo.Database, w WorkloaderType) (
 	id := models.MustID(ctx, db, ReservationCollection)
 	w.SetID(id)
 
+	// ensure the signers array are never nill cause it would cause issue
+	// in mongo when trying to push signature later on
+	reqDel := w.GetSigningRequestDelete()
+	if reqDel.Signers == nil {
+		reqDel.Signers = make([]int64, 0)
+		w.SetSigningRequestDelete(reqDel)
+	}
+
+	reqPro := w.GetSigningRequestProvision()
+	if reqPro.Signers == nil {
+		reqDel.Signers = make([]int64, 0)
+		w.SetSigningRequestProvision(reqPro)
+	}
+
 	_, err := db.Collection(WorkloadCollection).InsertOne(ctx, w)
 	if err != nil {
 		return 0, err

--- a/pkg/workloads/types/workloadpipeline.go
+++ b/pkg/workloads/types/workloadpipeline.go
@@ -30,25 +30,8 @@ func (p *WorkloadPipeline) checkProvisionSignatures() bool {
 		return true
 	}
 
-	in := func(i int64, l []int64) bool {
-		for _, x := range l {
-			if x == i {
-				return true
-			}
-		}
-		return false
-	}
-
-	signatures := p.w.GetSignaturesProvision()
-	var count int64
-	for _, signature := range signatures {
-		if !in(signature.Tid, request.Signers) {
-			continue
-		}
-		count++
-	}
-
-	return count >= request.QuorumMin
+	signers := countSignatures(p.w.GetSignaturesProvision(), request)
+	return int64(signers) >= request.QuorumMin
 }
 
 func (p *WorkloadPipeline) checkDeleteSignatures() bool {
@@ -63,25 +46,8 @@ func (p *WorkloadPipeline) checkDeleteSignatures() bool {
 		return false
 	}
 
-	in := func(i int64, l []int64) bool {
-		for _, x := range l {
-			if x == i {
-				return true
-			}
-		}
-		return false
-	}
-
-	signatures := p.w.GetSignaturesDelete()
-	var count int64
-	for _, signature := range signatures {
-		if !in(signature.Tid, request.Signers) {
-			continue
-		}
-		count++
-	}
-
-	return count >= request.QuorumMin
+	signers := countSignatures(p.w.GetSignaturesDelete(), request)
+	return int64(signers) >= request.QuorumMin
 }
 
 // Next gets new modified reservation, and true if the reservation has changed from the input


### PR DESCRIPTION
After this commit, user that are requested in the delete or provision
consensus are only able to push a signature once.

If they already have a signature registered and try to put a new one, an
400 bad request error will be returned by the API.

This change allow to simplify the way we deal with signature array
internally and should prevent issue like #141

fixes #141