### PR TITLE
Fix #162: Allow extending pools without CU or SU

### DIFF
--- a/pkg/workloads/reservation.go
+++ b/pkg/workloads/reservation.go
@@ -231,6 +231,9 @@ func (a *API) setupPool(r *http.Request) (interface{}, mw.Response) {
 
 	info, err := a.capacityPlanner.Reserve(reservation, currencies)
 	if err != nil {
+		if errors.Is(err, capacity.ErrTransparantCapacityExtension) {
+			return nil, mw.BadRequest(err)
+		}
 		return nil, mw.Error(err)
 	}
 


### PR DESCRIPTION
Specifically, allow a new pool reservation to modify an existing pool by only
adding new node ids. In such a scenario, an escrow would previously be
set up for 0 value, which would cause errors on the payouts. Now detect
this specific scenario, and in the escrow stage, immediatly mark the
reservation as paid, without checking for an actual payment. This way we
still have the reservation in DB for the blockchain behavior.

Also, actually allow adding new nodes to an existing pool (previously
all checks were done but the update itself did not happen), and detect
if a reservation will have no observeable effect (i.e. no added CU,SU,or
nodes). In case of the latter, reject the reservation.