### PR TITLE
Mark nodes as deleted instead of actually deleting

### DIFF
--- a/client/filter.go
+++ b/client/filter.go
@@ -15,6 +15,7 @@ type NodeFilter struct {
 	sru     *int64
 	hru     *int64
 	proofs  *bool
+	deleted *bool
 }
 
 // WithFarm filter with farm
@@ -59,6 +60,12 @@ func (n NodeFilter) WithProofs(proofs bool) NodeFilter {
 	return n
 }
 
+// WithDeleted filter with deleted nodes
+func (n NodeFilter) WithDeleted(deleted bool) NodeFilter {
+	n.deleted = &deleted
+	return n
+}
+
 // Apply fills query
 func (n NodeFilter) Apply(query url.Values) {
 
@@ -92,5 +99,9 @@ func (n NodeFilter) Apply(query url.Values) {
 
 	if n.proofs != nil {
 		query.Set("proofs", fmt.Sprint(*n.proofs))
+	}
+
+	if n.deleted != nil {
+		query.Set("deleted", fmt.Sprint(*n.deleted))
 	}
 }

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -92,6 +92,7 @@ type Node struct {
 	Approved          bool           `bson:"approved" json:"approved"`
 	PublicKeyHex      string         `bson:"public_key_hex" json:"public_key_hex"`
 	WgPorts           []int64        `bson:"wg_ports" json:"wg_ports"`
+	Deleted           bool           `bson:"deleted" json:"deleted"`
 }
 
 func NewNode() (Node, error) {

--- a/pkg/directory/node_handlers.go
+++ b/pkg/directory/node_handlers.go
@@ -51,6 +51,8 @@ func (s *NodeAPI) registerNode(r *http.Request) (interface{}, mw.Response) {
 
 	//make sure node can not set public config
 	n.PublicConfig = nil
+	// and it not immediately deleted
+	n.Deleted = false
 	if _, err := s.Add(r.Context(), db, n); err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, mw.NotFound(fmt.Errorf("farm with id:%d does not exists", n.FarmId))

--- a/pkg/workloads/conversion.go
+++ b/pkg/workloads/conversion.go
@@ -401,7 +401,7 @@ func farmForNodeID(ctx context.Context, db *mongo.Database, nodeID string) (int6
 
 func farmNodeIDs(ctx context.Context, db *mongo.Database, farmID int64) ([]string, error) {
 	var filter directorytypes.NodeFilter
-	filter = filter.WithFarmID(schema.ID(farmID))
+	filter = filter.WithFarmID(schema.ID(farmID)).ExcludeDeleted()
 
 	var nodes []directorytypes.Node
 	cur, err := filter.Find(ctx, db)

--- a/pkg/workloads/reservation.go
+++ b/pkg/workloads/reservation.go
@@ -1231,6 +1231,7 @@ func isAllFreeToUse(ctx context.Context, nodeIDs []string, db *mongo.Database) (
 	count, err := (directory.NodeFilter{}).
 		WithNodeIDs(nodeIDs).
 		WithFreeToUse(true).
+		ExcludeDeleted().
 		Count(ctx, db)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
From now on, set a tombstone marker on nodes which are deleted. A new
filter is added when listing nodes, to also show deleted nodes (which is
not done by default). Updates to nodes marked as deleted are also
prohibited (the node will not be found). However, to maintain old
behavior, the NodeCreate call _is_ allowed (and will now clear the
tombtone if present). Looking up  a specific node will always succeed.

Fix #164