### PR TITLE
Rename StatsAggregator to Stats for Container

### DIFF
--- a/cmds/tfuser/cmds_container.go
+++ b/cmds/tfuser/cmds_container.go
@@ -32,7 +32,7 @@ func generateContainer(c *cli.Context) error {
 		DiskType: workloads.DiskTypeSSD,
 	}
 
-	var sts []workloads.StatsAggregator
+	var sts []workloads.Stats
 	if s := c.String("stats"); s != "" {
 		// validating stdout argument
 		_, _, err := logger.RedisParseURL(s)
@@ -40,7 +40,7 @@ func generateContainer(c *cli.Context) error {
 			return err
 		}
 
-		ss := workloads.StatsAggregator{
+		ss := workloads.Stats{
 			Type: stats.RedisType,
 			Data: workloads.StatsRedis{
 				Endpoint: s,
@@ -99,7 +99,7 @@ func generateContainer(c *cli.Context) error {
 		WithVolumes(mounts).WithInteractive(c.Bool("corex")).
 		WithContainerCapacity(cap).
 		WithLogs(logs).
-		WithStatsAggregator(sts)
+		WithStats(sts)
 
 	if c.Int64("poolID") != 0 {
 		containerBuilder.WithPoolID(c.Int64("poolID"))

--- a/cmds/tfuser/cmds_container.go
+++ b/cmds/tfuser/cmds_container.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -40,11 +41,18 @@ func generateContainer(c *cli.Context) error {
 			return err
 		}
 
+		r := workloads.StatsRedis{
+			Endpoint: s,
+		}
+
+		data, err := json.Marshal(&r)
+		if err != nil {
+			return err
+		}
+
 		ss := workloads.Stats{
 			Type: stats.RedisType,
-			Data: workloads.StatsRedis{
-				Endpoint: s,
-			},
+			Data: data,
 		}
 
 		sts = append(sts, ss)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rusart/muxprom v0.0.0-20200323164249-36ea051efbe6
 	github.com/stellar/go v0.0.0-20200917104244-8dc2a7354bf8
 	github.com/stretchr/testify v1.6.1
-	github.com/threefoldtech/zos v0.4.0-rc9-b.0.20200918140104-b46553b0c680 // indirect
+	github.com/threefoldtech/zos v0.4.0-rc9-b.0.20200918140104-b46553b0c680
 	github.com/tyler-smith/go-bip39 v1.0.2
 	github.com/urfave/cli v1.22.4
 	github.com/zaibon/httpsig v0.0.0-20200401133919-ea9cb57b0946

--- a/models/generated/workloads/container.go
+++ b/models/generated/workloads/container.go
@@ -2,6 +2,7 @@ package workloads
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -139,8 +140,8 @@ type Logs struct {
 }
 
 type Stats struct {
-	Type string     `bson:"type" json:"type"`
-	Data StatsRedis `bson:"data" json:"data"`
+	Type string          `bson:"type" json:"type"`
+	Data json.RawMessage `bson:"data" json:"data"`
 }
 
 func (c Logs) SigingEncode(w io.Writer) error {

--- a/models/generated/workloads/container.go
+++ b/models/generated/workloads/container.go
@@ -23,7 +23,7 @@ type Container struct {
 	Interactive       bool                `bson:"interactive" json:"interactive"`
 	Volumes           []ContainerMount    `bson:"volumes" json:"volumes"`
 	NetworkConnection []NetworkConnection `bson:"network_connection" json:"network_connection"`
-	StatsAggregator   []StatsAggregator   `bson:"stats_aggregator" json:"stats_aggregator"`
+	Stats             []Stats             `bson:"stats" json:"stats"`
 	Logs              []Logs              `bson:"logs" json:"logs"`
 	Capacity          ContainerCapacity   `bson:"capcity" json:"capacity"`
 }
@@ -138,6 +138,11 @@ type Logs struct {
 	Data LogsRedis `bson:"data" json:"data"`
 }
 
+type Stats struct {
+	Type string     `bson:"type" json:"type"`
+	Data StatsRedis `bson:"data" json:"data"`
+}
+
 func (c Logs) SigingEncode(w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "%s", c.Type); err != nil {
 		return err
@@ -156,6 +161,10 @@ type LogsRedis struct {
 	// with the node public key.
 	SecretStdout string `bson:"secret_stdout" json:"secret_stdout"`
 	SecretStderr string `bson:"secret_stderr" json:"secret_stderr"`
+}
+
+type StatsRedis struct {
+	Endpoint string `bson:"endpoint" json:"endpoint"`
 }
 
 func (l LogsRedis) SigingEncode(w io.Writer) error {
@@ -214,12 +223,7 @@ func (n NetworkConnection) SigingEncode(w io.Writer) error {
 	return nil
 }
 
-type StatsAggregator struct {
-	Type string     `bson:"type" json:"type"`
-	Data StatsRedis `bson:"data" json:"data"`
-}
-
-func (s StatsAggregator) SigingEncode(w io.Writer) error {
+func (s Stats) SigingEncode(w io.Writer) error {
 	return nil
 	// if _, err := fmt.Fprintf(w, "%s", s.Type); err != nil {
 	// 	return err
@@ -228,8 +232,4 @@ func (s StatsAggregator) SigingEncode(w io.Writer) error {
 	// 	return err
 	// }
 	// return nil
-}
-
-type StatsRedis struct {
-	Endpoint string `bson:"stdout" json:"endpoint"`
 }

--- a/models/generated/workloads/workload.go
+++ b/models/generated/workloads/workload.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -415,4 +416,13 @@ func (i *ReservationInfo) GetReference() string {
 
 func (i *ReservationInfo) SetReference(ref string) {
 	i.Reference = ref
+}
+
+// Stub type not used (for now)
+type StatsAggregator struct {
+	stub bool `bson:"stub" json:"stub"` // To be defined
+}
+
+func (s StatsAggregator) SigingEncode(w io.Writer) error {
+	return nil
 }

--- a/models/generated/workloads/workload.go
+++ b/models/generated/workloads/workload.go
@@ -420,7 +420,7 @@ func (i *ReservationInfo) SetReference(ref string) {
 
 // Stub type not used (for now)
 type StatsAggregator struct {
-	stub bool `bson:"stub" json:"stub"` // To be defined
+	// To be defined
 }
 
 func (s StatsAggregator) SigingEncode(w io.Writer) error {

--- a/provision/builders/containerBuilder.go
+++ b/provision/builders/containerBuilder.go
@@ -135,8 +135,8 @@ func (c *ContainerBuilder) WithVolumes(mounts []workloads.ContainerMount) *Conta
 }
 
 // WithStatsAggregator sets the stats aggregators to the container
-func (c *ContainerBuilder) WithStatsAggregator(aggregators []workloads.StatsAggregator) *ContainerBuilder {
-	c.Container.StatsAggregator = aggregators
+func (c *ContainerBuilder) WithStats(stats []workloads.Stats) *ContainerBuilder {
+	c.Container.Stats = stats
 	return c
 }
 

--- a/provision/builders/containerBuilder.go
+++ b/provision/builders/containerBuilder.go
@@ -134,7 +134,7 @@ func (c *ContainerBuilder) WithVolumes(mounts []workloads.ContainerMount) *Conta
 	return c
 }
 
-// WithStatsAggregator sets the stats aggregators to the container
+// WithStats sets the stats aggregators to the container
 func (c *ContainerBuilder) WithStats(stats []workloads.Stats) *ContainerBuilder {
 	c.Container.Stats = stats
 	return c


### PR DESCRIPTION
There is a `StatsAggregator` generic defined on original spec, and the same name was used to defines *Container Statistics*, but container statistics are not generic and are specific to containers only.

This change rename `StatsAggregator` type and field name for container, to switch to just `Stats`.