### PR TITLE
Update 'Siging' to 'Signing' typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: tfexplorer tffarmer
 
 getdeps:
 	@echo "Installing golint" && go install golang.org/x/lint/golint
-	@echo "Installing gocyclo" && go install github.com/fzipp/gocyclo
+	@echo "Installing gocyclo" && go install github.com/fzipp/gocyclo/cmd/gocyclo
 	@echo "Installing misspell" && go install github.com/client9/misspell/cmd/misspell
 	@echo "Installing ineffassign" && go install github.com/gordonklaus/ineffassign
 	@echo "Installing statik" && go install github.com/rakyll/statik

--- a/models/generated/workloads/container.go
+++ b/models/generated/workloads/container.go
@@ -76,17 +76,17 @@ func (c *Container) SignatureChallenge() ([]byte, error) {
 		return nil, err
 	}
 	for _, v := range c.Volumes {
-		if err := v.SigingEncode(b); err != nil {
+		if err := v.SigningEncode(b); err != nil {
 			return nil, err
 		}
 	}
 	for _, v := range c.NetworkConnection {
-		if err := v.SigingEncode(b); err != nil {
+		if err := v.SigningEncode(b); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := c.Capacity.SigingEncode(b); err != nil {
+	if err := c.Capacity.SigningEncode(b); err != nil {
 		return nil, err
 	}
 
@@ -100,7 +100,7 @@ type ContainerCapacity struct {
 	DiskType DiskTypeEnum `bson:"disk_type" json:"disk_type"`
 }
 
-func (c ContainerCapacity) SigingEncode(w io.Writer) error {
+func (c ContainerCapacity) SigningEncode(w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "%d", c.Cpu); err != nil {
 		return err
 	}
@@ -144,11 +144,11 @@ type Stats struct {
 	Data json.RawMessage `bson:"data" json:"data"`
 }
 
-func (c Logs) SigingEncode(w io.Writer) error {
+func (c Logs) SigningEncode(w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "%s", c.Type); err != nil {
 		return err
 	}
-	if err := c.Data.SigingEncode(w); err != nil {
+	if err := c.Data.SigningEncode(w); err != nil {
 		return err
 	}
 	return nil
@@ -168,7 +168,7 @@ type StatsRedis struct {
 	Endpoint string `bson:"endpoint" json:"endpoint"`
 }
 
-func (l LogsRedis) SigingEncode(w io.Writer) error {
+func (l LogsRedis) SigningEncode(w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "%s", l.Stdout); err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ type ContainerMount struct {
 	Mountpoint string `bson:"mountpoint" json:"mountpoint"`
 }
 
-func (c ContainerMount) SigingEncode(w io.Writer) error {
+func (c ContainerMount) SigningEncode(w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "%s", c.VolumeId); err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ type NetworkConnection struct {
 	YggdrasilIP bool   `bson:"yggdrasil_ip" json:"yggdrasil_ip"`
 }
 
-func (n NetworkConnection) SigingEncode(w io.Writer) error {
+func (n NetworkConnection) SigningEncode(w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "%s", n.NetworkId); err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func (n NetworkConnection) SigingEncode(w io.Writer) error {
 	return nil
 }
 
-func (s Stats) SigingEncode(w io.Writer) error {
+func (s Stats) SigningEncode(w io.Writer) error {
 	return nil
 	// if _, err := fmt.Fprintf(w, "%s", s.Type); err != nil {
 	// 	return err

--- a/models/generated/workloads/network.go
+++ b/models/generated/workloads/network.go
@@ -60,7 +60,7 @@ type WireguardPeer struct {
 	AllowedIprange []schema.IPRange `bson:"allowed_iprange" json:"allowed_iprange"`
 }
 
-func (p *WireguardPeer) SigingEncode(w io.Writer) error {
+func (p *WireguardPeer) SigningEncode(w io.Writer) error {
 	if _, err := fmt.Fprintf(w, "%s", p.PublicKey); err != nil {
 		return err
 	}

--- a/models/generated/workloads/network_resource.go
+++ b/models/generated/workloads/network_resource.go
@@ -53,7 +53,7 @@ func (n *NetworkResource) SignatureChallenge() ([]byte, error) {
 		return nil, err
 	}
 	for _, p := range n.Peers {
-		if err := p.SigingEncode(b); err != nil {
+		if err := p.SigningEncode(b); err != nil {
 			return nil, err
 		}
 	}

--- a/models/generated/workloads/workload.go
+++ b/models/generated/workloads/workload.go
@@ -434,6 +434,6 @@ type StatsAggregator struct {
 	// To be defined
 }
 
-func (s StatsAggregator) SigingEncode(w io.Writer) error {
+func (s StatsAggregator) SigningEncode(w io.Writer) error {
 	return nil
 }

--- a/models/generated/workloads/zdb.go
+++ b/models/generated/workloads/zdb.go
@@ -56,7 +56,7 @@ func (z *ZDB) SignatureChallenge() ([]byte, error) {
 		return nil, err
 	}
 	for _, s := range z.StatsAggregator {
-		if err := s.SigingEncode(b); err != nil {
+		if err := s.SigningEncode(b); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Multiple time `SigingEncode` was used in place of `SigningEncode`
This fix `gocyclo` install aswell, like in: https://github.com/threefoldtech/zos/commit/cc8838abef4900e02856e9ce3560b9bab8879c05