### PR TITLE
make sure that we send queue only if no more workloads to process

### DIFF
--- a/pkg/workloads/reservation.go
+++ b/pkg/workloads/reservation.go
@@ -590,16 +590,22 @@ func (a *API) workloads(r *http.Request) (interface{}, mw.Response) {
 		return workloads, mw.Ok().WithHeader("x-last-id", fmt.Sprint(lastID))
 	}
 
-	queued, err := a.queued(r.Context(), db, nodeID, maxPageSize)
-	if err != nil {
-		return nil, mw.Error(err)
-	}
+	if len(workloads) == 0 {
+		// only if the workloads list is empty
+		// we can check the queues
+		// queues usually have the workloads with older ids that
+		// are now possible to process.
+		queued, err := a.queued(r.Context(), db, nodeID, maxPageSize)
+		if err != nil {
+			return nil, mw.Error(err)
+		}
 
-	log.Debug().Msgf("%d queue", len(queued))
-	for _, workload := range queued {
-		workloads = append(workloads, workload)
-		if id := workload.GetID(); id > lastID {
-			lastID = id
+		log.Debug().Msgf("%d queue", len(queued))
+		for _, workload := range queued {
+			workloads = append(workloads, workload)
+			if id := workload.GetID(); id > lastID {
+				lastID = id
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #225

So in this fix we should only return "queued" workloads only if there are nothing to return from the reservations query. The queue is only to process older reservations that are suddenly available for processing (for example expired reservations)

But now many reservations are ready from the beginning if the pool has capacity, so we store the reservation in both the reservation collections, and also we push it to the queue. 
This will make the node get the reservations 2 times since the workloads endpoint will query matching reservations, and also the queue. then the node will receive the same reservation 2 times.

instead we only check the queue if no other reservations available