### PR TITLE
make sure to validate gw register request

### DIFF
--- a/pkg/directory/gateway_handlers.go
+++ b/pkg/directory/gateway_handlers.go
@@ -26,6 +26,11 @@ func (s *GatewayAPI) registerGateway(r *http.Request) (interface{}, mw.Response)
 		return nil, mw.BadRequest(err)
 	}
 
+	keyID := httpsig.KeyIDFromContext(r.Context())
+	if gw.NodeId != keyID {
+		return nil, mw.Forbidden(fmt.Errorf("trying to register a gateway with nodeID %s while you are %s", gw.NodeId, keyID))
+	}
+
 	if err := gw.Validate(); err != nil {
 		return nil, mw.BadRequest(err)
 	}

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -67,7 +67,7 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	gwAuthMW := mw.NewAuthMiddleware(nodeVerifier)
 	gwAuthenticated.Use(gwAuthMW.Middleware)
 
-	gw.HandleFunc("", mw.AsHandlerFunc(gwAPI.registerGateway)).Methods("POST").Name("gateway-register-v1")
+	gwAuthenticated.HandleFunc("", mw.AsHandlerFunc(gwAPI.registerGateway)).Methods("POST").Name("gateway-register-v1")
 	gw.HandleFunc("", mw.AsHandlerFunc(gwAPI.listGateways)).Methods("GET").Name("gateway-list-v1")
 	gw.HandleFunc("/{node_id}", mw.AsHandlerFunc(gwAPI.gatewayDetail)).Methods("GET").Name(("gateway-get-v1"))
 	gwAuthenticated.HandleFunc("/{node_id}/uptime", mw.AsHandlerFunc(gwAPI.Requires("node_id", gwAPI.updateUptimeHandler))).Methods("POST").Name("gateway-uptime-v1")


### PR DESCRIPTION
## Fixes
- Make sure that the gateway registration actually validate that the gateway node id is owned by the requester by validating it against the httpsig key.

# Features
- Validate managed domains that they are actually managed by that gateway by validating the TXT record of `__owner__.<domain>` that it has the right identity. (requires https://github.com/threefoldtech/tfgateway/pull/55)
 