### PR TITLE
Farm custom pricing

### DIFF
--- a/cmds/tffarmer/farm.go
+++ b/cmds/tffarmer/farm.go
@@ -29,7 +29,7 @@ func registerFarm(c *cli.Context) (err error) {
 
 	farm := directory.Farm{
 		Name:            name,
-		ThreebotId:      int64(userid.ThreebotID),
+		ThreebotID:      int64(userid.ThreebotID),
 		Email:           schema.Email(email),
 		IyoOrganization: iyo,
 		WalletAddresses: addresses,
@@ -97,7 +97,7 @@ func formatFarm(farm directory.Farm) string {
 	fmt.Fprintf(b, "ID: %d\n", farm.ID)
 	fmt.Fprintf(b, "Name: %s\ns", farm.Name)
 	fmt.Fprintf(b, "Email: %s\n", farm.Email)
-	fmt.Fprintf(b, "Farmer TheebotID: %d\n", farm.ThreebotId)
+	fmt.Fprintf(b, "Farmer TheebotID: %d\n", farm.ThreebotID)
 	fmt.Fprintf(b, "IYO organization: %s\n", farm.IyoOrganization)
 	fmt.Fprintf(b, "Wallet addresses:\n")
 	for _, a := range farm.WalletAddresses {

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,7 @@ go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.mongodb.org/mongo-driver v1.3.0/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.3.2 h1:IYppNjEV/C+/3VPbhHVxQ4t04eVW0cLp0/pNdW++6Ug=
 go.mongodb.org/mongo-driver v1.3.2/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
+go.mongodb.org/mongo-driver v1.4.6 h1:rh7GdYmDrb8AQSkF8yteAus8qYOgOASWDOv1BWqBXkU=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/migrations/wallet_address/main.go
+++ b/migrations/wallet_address/main.go
@@ -19,7 +19,7 @@ import (
 
 type oldType struct {
 	ID              schema.ID                     `bson:"_id" json:"id"`
-	ThreebotId      int64                         `bson:"threebot_id" json:"threebot_id"`
+	ThreebotID      int64                         `bson:"threebot_id" json:"threebot_id"`
 	IyoOrganization string                        `bson:"iyo_organization" json:"iyo_organization"`
 	Name            string                        `bson:"name" json:"name"`
 	WalletAddresses []string                      `bson:"wallet_addresses" json:"wallet_addresses"`
@@ -81,7 +81,7 @@ func main() {
 
 		new := types.Farm{
 			ID:              old.ID,
-			ThreebotId:      old.ThreebotId,
+			ThreebotID:      old.ThreebotID,
 			IyoOrganization: old.IyoOrganization,
 			Name:            old.Name,
 			WalletAddresses: make([]generated.WalletAddress, len(old.WalletAddresses)),

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -22,7 +22,7 @@ type NodeCloudUnitPrice struct {
 	CU       float64           `bson:"cu" json:"cu"`
 	SU       float64           `bson:"su" json:"su"`
 	NU       float64           `bson:"nu" json:"nu"`
-	IP4U     float64           `bson:"ip4u" json:"ip4u"`
+	IPv4U    float64           `bson:"ipv4u" json:"ipv4u"`
 }
 
 func NewNodeCloudUnitPrice() NodeCloudUnitPrice {
@@ -30,24 +30,23 @@ func NewNodeCloudUnitPrice() NodeCloudUnitPrice {
 }
 
 type Farm struct {
-	ID                    schema.ID           `bson:"_id" json:"id"`
-	ThreebotId            int64               `bson:"threebot_id" json:"threebot_id"`
-	IyoOrganization       string              `bson:"iyo_organization" json:"iyo_organization"`
-	Name                  string              `bson:"name" json:"name"`
-	WalletAddresses       []WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
-	Location              Location            `bson:"location" json:"location"`
-	Email                 schema.Email        `bson:"email" json:"email"`
-	ResourcePrices        []NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
-	PrefixZero            schema.IPRange      `bson:"prefix_zero" json:"prefix_zero"`
-	IPAddresses           []PublicIP          `bson:"ipaddresses" json:"ipaddresses"`
-	EnableCustomPricing   bool                `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
-	DefaultCloudUnitPrice NodeCloudUnitPrice  `bson:"default_cloud_units_price" json:"default_cloud_units_price"`
+	ID                     schema.ID           `bson:"_id" json:"id"`
+	ThreebotId             int64               `bson:"threebot_id" json:"threebot_id"`
+	IyoOrganization        string              `bson:"iyo_organization" json:"iyo_organization"`
+	Name                   string              `bson:"name" json:"name"`
+	WalletAddresses        []WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
+	Location               Location            `bson:"location" json:"location"`
+	Email                  schema.Email        `bson:"email" json:"email"`
+	ResourcePrices         []NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
+	PrefixZero             schema.IPRange      `bson:"prefix_zero" json:"prefix_zero"`
+	IPAddresses            []PublicIP          `bson:"ipaddresses" json:"ipaddresses"`
+	EnableCustomPricing    bool                `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
+	DefaultCloudUnitsPrice NodeCloudUnitPrice  `bson:"default_cloudunits_price" json:"default_cloudunits_price"`
 }
 type FarmThreebotPrice struct {
-	ID                   schema.ID          `bson:"_id" json:"id"`
 	ThreebotId           int64              `bson:"threebot_id" json:"threebot_id"`
 	FarmId               int64              `bson:"farm_id" json:"farm_id"`
-	CustomCloudUnitPrice NodeCloudUnitPrice `bson:"custom_cloud_unit_price" json:"custom_cloud_unit_price"`
+	CustomCloudUnitPrice NodeCloudUnitPrice `bson:"custom_cloudunits_price" json:"custom_cloudunits_price"`
 }
 
 func NewFarm() (Farm, error) {

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -31,7 +31,7 @@ func NewNodeCloudUnitPrice() NodeCloudUnitPrice {
 
 type Farm struct {
 	ID                  schema.ID           `bson:"_id" json:"id"`
-	ThreebotId          int64               `bson:"threebot_id" json:"threebot_id"`
+	ThreebotID          int64               `bson:"threebot_id" json:"threebot_id"`
 	IyoOrganization     string              `bson:"iyo_organization" json:"iyo_organization"`
 	Name                string              `bson:"name" json:"name"`
 	WalletAddresses     []WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -25,11 +25,6 @@ type NodeCloudUnitPrice struct {
 	EnableCustomPricing bool              `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
 }
 
-type CustomNodeCloudUnitPrice struct {
-	ThreebotId int64 `bson:"threebot_id" json:"threebot_id"`
-	NodeCloudUnitPrice
-}
-
 func NewNodeCloudUnitPrice() NodeCloudUnitPrice {
 	return NodeCloudUnitPrice{Currency: PriceCurrencyTFT}
 }

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -30,18 +30,18 @@ func NewNodeCloudUnitPrice() NodeCloudUnitPrice {
 }
 
 type Farm struct {
-	ID                     schema.ID           `bson:"_id" json:"id"`
-	ThreebotId             int64               `bson:"threebot_id" json:"threebot_id"`
-	IyoOrganization        string              `bson:"iyo_organization" json:"iyo_organization"`
-	Name                   string              `bson:"name" json:"name"`
-	WalletAddresses        []WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
-	Location               Location            `bson:"location" json:"location"`
-	Email                  schema.Email        `bson:"email" json:"email"`
-	ResourcePrices         []NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
-	PrefixZero             schema.IPRange      `bson:"prefix_zero" json:"prefix_zero"`
-	IPAddresses            []PublicIP          `bson:"ipaddresses" json:"ipaddresses"`
-	EnableCustomPricing    bool                `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
-	DefaultCloudUnitsPrice NodeCloudUnitPrice  `bson:"default_cloudunits_price" json:"default_cloudunits_price"`
+	ID                  schema.ID           `bson:"_id" json:"id"`
+	ThreebotId          int64               `bson:"threebot_id" json:"threebot_id"`
+	IyoOrganization     string              `bson:"iyo_organization" json:"iyo_organization"`
+	Name                string              `bson:"name" json:"name"`
+	WalletAddresses     []WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
+	Location            Location            `bson:"location" json:"location"`
+	Email               schema.Email        `bson:"email" json:"email"`
+	ResourcePrices      []NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
+	PrefixZero          schema.IPRange      `bson:"prefix_zero" json:"prefix_zero"`
+	IPAddresses         []PublicIP          `bson:"ipaddresses" json:"ipaddresses"`
+	EnableCustomPricing bool                `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
+	FarmCloudUnitsPrice NodeCloudUnitPrice  `bson:"farm_cloudunits_price" json:"farm_cloudunits_price"`
 }
 type FarmThreebotPrice struct {
 	ThreebotId           int64              `bson:"threebot_id" json:"threebot_id"`

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -18,11 +18,10 @@ type NodeResourcePrice struct {
 }
 
 type NodeCloudUnitPrice struct {
-	Currency            PriceCurrencyEnum `bson:"currency" json:"currency"`
-	CU                  float64           `bson:"cu" json:"cu"`
-	SU                  float64           `bson:"su" json:"su"`
-	NU                  float64           `bson:"nu" json:"nu"`
-	EnableCustomPricing bool              `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
+	Currency PriceCurrencyEnum `bson:"currency" json:"currency"`
+	CU       float64           `bson:"cu" json:"cu"`
+	SU       float64           `bson:"su" json:"su"`
+	NU       float64           `bson:"nu" json:"nu"`
 }
 
 func NewNodeCloudUnitPrice() NodeCloudUnitPrice {
@@ -40,6 +39,7 @@ type Farm struct {
 	ResourcePrices        []NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
 	PrefixZero            schema.IPRange      `bson:"prefix_zero" json:"prefix_zero"`
 	IPAddresses           []PublicIP          `bson:"ipaddresses" json:"ipaddresses"`
+	EnableCustomPricing   bool                `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
 	DefaultCloudUnitPrice NodeCloudUnitPrice  `bson:"default_cloud_units_price" json:"default_cloud_units_price"`
 }
 type FarmThreebotPrice struct {

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -8,17 +8,50 @@ import (
 	schema "github.com/threefoldtech/tfexplorer/schema"
 )
 
+type NodeResourcePrice struct {
+	Currency PriceCurrencyEnum `bson:"currency" json:"currency"`
+	Cru      float64           `bson:"cru" json:"cru"`
+	Mru      float64           `bson:"mru" json:"mru"`
+	Hru      float64           `bson:"hru" json:"hru"`
+	Sru      float64           `bson:"sru" json:"sru"`
+	Nru      float64           `bson:"nru" json:"nru"`
+}
+
+type NodeCloudUnitPrice struct {
+	Currency            PriceCurrencyEnum `bson:"currency" json:"currency"`
+	CU                  float64           `bson:"cu" json:"cu"`
+	SU                  float64           `bson:"su" json:"su"`
+	NU                  float64           `bson:"nu" json:"nu"`
+	EnableCustomPricing bool              `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
+}
+
+type CustomNodeCloudUnitPrice struct {
+	ThreebotId int64 `bson:"threebot_id" json:"threebot_id"`
+	NodeCloudUnitPrice
+}
+
+func NewNodeCloudUnitPrice() NodeCloudUnitPrice {
+	return NodeCloudUnitPrice{Currency: PriceCurrencyTFT}
+}
+
 type Farm struct {
-	ID              schema.ID           `bson:"_id" json:"id"`
-	ThreebotId      int64               `bson:"threebot_id" json:"threebot_id"`
-	IyoOrganization string              `bson:"iyo_organization" json:"iyo_organization"`
-	Name            string              `bson:"name" json:"name"`
-	WalletAddresses []WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
-	Location        Location            `bson:"location" json:"location"`
-	Email           schema.Email        `bson:"email" json:"email"`
-	ResourcePrices  []NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
-	PrefixZero      schema.IPRange      `bson:"prefix_zero" json:"prefix_zero"`
-	IPAddresses     []PublicIP          `bson:"ipaddresses" json:"ipaddresses"`
+	ID                    schema.ID           `bson:"_id" json:"id"`
+	ThreebotId            int64               `bson:"threebot_id" json:"threebot_id"`
+	IyoOrganization       string              `bson:"iyo_organization" json:"iyo_organization"`
+	Name                  string              `bson:"name" json:"name"`
+	WalletAddresses       []WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
+	Location              Location            `bson:"location" json:"location"`
+	Email                 schema.Email        `bson:"email" json:"email"`
+	ResourcePrices        []NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
+	PrefixZero            schema.IPRange      `bson:"prefix_zero" json:"prefix_zero"`
+	IPAddresses           []PublicIP          `bson:"ipaddresses" json:"ipaddresses"`
+	DefaultCloudUnitPrice NodeCloudUnitPrice  `bson:"default_cloud_units_price" json:"default_cloud_units_price"`
+}
+type FarmThreebotPrice struct {
+	ID                   schema.ID          `bson:"_id" json:"id"`
+	ThreebotId           int64              `bson:"threebot_id" json:"threebot_id"`
+	FarmId               int64              `bson:"farm_id" json:"farm_id"`
+	CustomCloudUnitPrice NodeCloudUnitPrice `bson:"custom_cloud_unit_price" json:"custom_cloud_unit_price"`
 }
 
 func NewFarm() (Farm, error) {
@@ -33,15 +66,6 @@ func NewFarm() (Farm, error) {
 type WalletAddress struct {
 	Asset   string `bson:"asset" json:"asset"`
 	Address string `bson:"address" json:"address"`
-}
-
-type NodeResourcePrice struct {
-	Currency PriceCurrencyEnum `bson:"currency" json:"currency"`
-	Cru      float64           `bson:"cru" json:"cru"`
-	Mru      float64           `bson:"mru" json:"mru"`
-	Hru      float64           `bson:"hru" json:"hru"`
-	Sru      float64           `bson:"sru" json:"sru"`
-	Nru      float64           `bson:"nru" json:"nru"`
 }
 
 func NewNodeResourcePrice() (NodeResourcePrice, error) {

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -44,8 +44,8 @@ type Farm struct {
 	FarmCloudUnitsPrice NodeCloudUnitPrice  `bson:"farm_cloudunits_price" json:"farm_cloudunits_price"`
 }
 type FarmThreebotPrice struct {
-	ThreebotId           int64              `bson:"threebot_id" json:"threebot_id"`
-	FarmId               int64              `bson:"farm_id" json:"farm_id"`
+	ThreebotID           int64              `bson:"threebot_id" json:"threebot_id"`
+	FarmID               int64              `bson:"farm_id" json:"farm_id"`
 	CustomCloudUnitPrice NodeCloudUnitPrice `bson:"custom_cloudunits_price" json:"custom_cloudunits_price"`
 }
 

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -22,6 +22,7 @@ type NodeCloudUnitPrice struct {
 	CU       float64           `bson:"cu" json:"cu"`
 	SU       float64           `bson:"su" json:"su"`
 	NU       float64           `bson:"nu" json:"nu"`
+	IP4U     float64           `bson:"ip4u" json:"ip4u"`
 }
 
 func NewNodeCloudUnitPrice() NodeCloudUnitPrice {

--- a/mw/action.go
+++ b/mw/action.go
@@ -12,7 +12,7 @@ import (
 type Response interface {
 	Status() int
 	Err() error
-
+	ErrorAsBytes() []byte
 	// header getter
 	Header() http.Header
 	// header setter
@@ -69,6 +69,10 @@ func (r genericResponse) Status() int {
 
 func (r genericResponse) Err() error {
 	return r.err
+}
+
+func (r genericResponse) ErrorAsBytes() []byte {
+	return []byte(r.err.Error())
 }
 
 func (r genericResponse) Header() http.Header {

--- a/pkg/capacity/planner.go
+++ b/pkg/capacity/planner.go
@@ -347,7 +347,7 @@ func (p *NaivePlanner) reserve(reservation types.Reservation, currencies []strin
 		}
 	} else {
 		// create new pool
-		pool = types.NewPool(reservation.ID, reservation.CustomerTid, data.NodeIDs)
+		pool = types.NewPool(reservation.ID, reservation.CustomerTid, reservation.SponsorTid, data.NodeIDs)
 		pool, err = types.CapacityPoolCreate(p.ctx, p.db, pool)
 		if err != nil {
 			return pi, errors.Wrap(err, "could not create new capacity pool")

--- a/pkg/capacity/types/pool.go
+++ b/pkg/capacity/types/pool.go
@@ -59,7 +59,8 @@ type (
 		// CustomerTid is the threebot id of the pool owner. Only the owner can
 		// assign workloads to the pool
 		CustomerTid int64 `bson:"customer_tid" json:"customer_tid"`
-		SponsorTid  int64 `bson:"sponsor_tid" json:"sponsor_tid"`
+		// SponsorTid is the original sponsor of the pool when created.
+		SponsorTid int64 `bson:"sponsor_tid" json:"sponsor_tid"`
 
 		// ActiveWorkloadIDs for this pool, this list contains only unique entries
 		ActiveWorkloadIDs []schema.ID `bson:"active_workload_ids" json:"active_workload_ids"`

--- a/pkg/capacity/types/pool.go
+++ b/pkg/capacity/types/pool.go
@@ -59,6 +59,7 @@ type (
 		// CustomerTid is the threebot id of the pool owner. Only the owner can
 		// assign workloads to the pool
 		CustomerTid int64 `bson:"customer_tid" json:"customer_tid"`
+		SponsorTid  int64 `bson:"sponsor_tid" json:"sponsor_tid"`
 
 		// ActiveWorkloadIDs for this pool, this list contains only unique entries
 		ActiveWorkloadIDs []schema.ID `bson:"active_workload_ids" json:"active_workload_ids"`
@@ -76,7 +77,7 @@ var (
 // NewPool sets up a new pool, ready to use, with the given data.
 //
 // If id is 0, it will be set on first save
-func NewPool(id schema.ID, ownerID int64, nodeIDs []string) Pool {
+func NewPool(id schema.ID, ownerID int64, sponsorTID int64, nodeIDs []string) Pool {
 	return Pool{
 		ID:                id,
 		Cus:               0,
@@ -87,6 +88,7 @@ func NewPool(id schema.ID, ownerID int64, nodeIDs []string) Pool {
 		ActiveSU:          0,
 		EmptyAt:           math.MaxInt64,
 		CustomerTid:       ownerID,
+		SponsorTid:        sponsorTID,
 		ActiveWorkloadIDs: []schema.ID{},
 	}
 }

--- a/pkg/capacity/types/reservation.go
+++ b/pkg/capacity/types/reservation.go
@@ -42,6 +42,8 @@ type (
 		DataReservation   ReservationData `bson:"data_reservation" json:"data_reservation"`
 		CustomerTid       int64           `bson:"customer_tid" json:"customer_tid"`
 		CustomerSignature string          `bson:"customer_signature" json:"customer_signature"`
+		SponsorTid        int64           `bson:"sponsor_tid" json:"sponsor_tid"`
+		SponsorSignature  string          `bson:"sponsor_signature" json:"sponsor_signature"`
 	}
 
 	// ReservationData is the actual data sent in a capacity pool reservation. If
@@ -76,6 +78,9 @@ func (pr *Reservation) Validate() error {
 
 	if len(pr.CustomerSignature) == 0 {
 		return errors.New("customer_signature is required")
+	}
+	if pr.SponsorTid != 0 && len(pr.SponsorSignature) == 0 {
+		return errors.New("sponsor_signature is required")
 	}
 
 	if len(pr.DataReservation.NodeIDs) == 0 {

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -70,7 +70,6 @@ func (f *FarmAPI) updateFarm(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, mw.Error(err)
 	}
-
 	return nil, mw.Ok()
 }
 
@@ -293,11 +292,12 @@ func (f *FarmAPI) createOrUpdateFarmCustomPrice(r *http.Request) (interface{}, m
 	ctx := r.Context()
 
 	db := mw.Database(r)
-	price, err := f.GetFarmCustomPriceForThreebot(ctx, db, postedFarmThreebotPrice.FarmId, postedFarmThreebotPrice.ThreebotId)
+
+	err := f.FarmThreebotPriceCreateOrUpdate(ctx, db, postedFarmThreebotPrice)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	return price, nil
+	return nil, mw.Ok()
 }
 
 func (f *FarmAPI) deleteFarmCustomPrice(r *http.Request) (interface{}, mw.Response) {

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -299,3 +299,20 @@ func (f *FarmAPI) createOrUpdateFarmCustomPrice(r *http.Request) (interface{}, m
 	}
 	return price, nil
 }
+
+func (f *FarmAPI) deleteFarmCustomPrice(r *http.Request) (interface{}, mw.Response) {
+
+	var postedFarmThreebotPrice directory.FarmThreebotPrice
+	if err := json.NewDecoder(r.Body).Decode(&postedFarmThreebotPrice); err != nil {
+		return nil, mw.BadRequest(err)
+	}
+
+	ctx := r.Context()
+
+	db := mw.Database(r)
+	err := f.DeleteFarmThreebotCustomPrice(ctx, db, postedFarmThreebotPrice.FarmId, postedFarmThreebotPrice.ThreebotId)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+	return nil, mw.Ok()
+}

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -247,7 +247,10 @@ func (f *FarmAPI) getFarmCustomPrices(r *http.Request) (interface{}, mw.Response
 	// Get the farm from the middleware context
 	sid := mux.Vars(r)["farm_id"]
 
-	farmId, err := strconv.ParseInt(sid, 10, 64)
+	farmID, err := strconv.ParseInt(sid, 10, 64)
+	if err != nil {
+		return nil, mw.BadRequest(errors.Errorf("invalid farm id"))
+	}
 	ctx := r.Context()
 
 	db := mw.Database(r)
@@ -258,25 +261,25 @@ func (f *FarmAPI) getFarmCustomPrices(r *http.Request) (interface{}, mw.Response
 	}
 	sauthenticatedThreebotCaller := r.Header.Get("Threebot-Id")
 	// if authenticated is not the farm owner or the threebot of the custom price we return bad request too.
-	authenticatedThreebotCallerId, err := strconv.ParseInt(sauthenticatedThreebotCaller, 10, 64)
+	authenticatedThreebotCallerID, err := strconv.ParseInt(sauthenticatedThreebotCaller, 10, 64)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
 
-	farm, err := f.GetByID(ctx, db, farmId)
+	farm, err := f.GetByID(ctx, db, farmID)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	farmerId := farm.ThreebotId
-	prices, _, err := f.GetFarmCustomPrices(ctx, db, farmId)
+	farmerID := farm.ThreebotId
+	prices, _, err := f.GetFarmCustomPrices(ctx, db, farmID)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	if farmerId == authenticatedThreebotCallerId {
+	if farmerID == authenticatedThreebotCallerID {
 		return prices, nil // return all of them
 	}
 	prices = nil // reset the slice
-	priceToReturn, err := f.GetFarmCustomPriceForThreebot(ctx, db, farmId, authenticatedThreebotCallerId)
+	priceToReturn, err := f.GetFarmCustomPriceForThreebot(ctx, db, farmID, authenticatedThreebotCallerID)
 	if err != nil {
 		return prices, mw.Ok()
 	}
@@ -294,11 +297,11 @@ func (f *FarmAPI) getFarmCustomPriceForThreebot(r *http.Request) (interface{}, m
 	}
 	sauthenticatedThreebotCaller := r.Header.Get("Threebot-Id")
 	// if authenticated is not the farm owner or the threebot of the custom price we return bad request too.
-	authenticatedThreebotCallerId, err := strconv.ParseInt(sauthenticatedThreebotCaller, 10, 64)
+	authenticatedThreebotCallerID, err := strconv.ParseInt(sauthenticatedThreebotCaller, 10, 64)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	farmId, err := strconv.ParseInt(sfid, 10, 64)
+	farmID, err := strconv.ParseInt(sfid, 10, 64)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 
@@ -306,20 +309,20 @@ func (f *FarmAPI) getFarmCustomPriceForThreebot(r *http.Request) (interface{}, m
 	ctx := r.Context()
 
 	db := mw.Database(r)
-	farm, err := f.GetByID(ctx, db, farmId)
+	farm, err := f.GetByID(ctx, db, farmID)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	farmerId := farm.ThreebotId
-	threebotId, err := strconv.ParseInt(stid, 10, 64)
+	farmerID := farm.ThreebotId
+	threebotID, err := strconv.ParseInt(stid, 10, 64)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	if authenticatedThreebotCallerId != threebotId && authenticatedThreebotCallerId != farmerId {
+	if authenticatedThreebotCallerID != threebotID && authenticatedThreebotCallerID != farmerID {
 		return nil, mw.BadRequest(errors.Errorf("not allowed to see that deal"))
 	}
 
-	price, err := f.GetFarmCustomPriceForThreebot(ctx, db, farmId, threebotId)
+	price, err := f.GetFarmCustomPriceForThreebot(ctx, db, farmID, threebotID)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
@@ -356,7 +359,7 @@ func (f *FarmAPI) deleteFarmCustomPrice(r *http.Request) (interface{}, mw.Respon
 	ctx := r.Context()
 
 	db := mw.Database(r)
-	err := f.DeleteFarmThreebotCustomPrice(ctx, db, postedFarmThreebotPrice.FarmId, postedFarmThreebotPrice.ThreebotId)
+	err := f.DeleteFarmThreebotCustomPrice(ctx, db, postedFarmThreebotPrice.FarmID, postedFarmThreebotPrice.ThreebotID)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -393,6 +393,9 @@ func (f *FarmAPI) deleteFarmCustomPrice(r *http.Request) (interface{}, mw.Respon
 	}
 
 	farm, err := f.GetByID(ctx, db, postedFarmThreebotPrice.FarmID)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
 	if farm.ThreebotID != authenticatedThreebotCallerID {
 		return nil, mw.BadRequest(errors.Errorf("not allowed to create or update on this farm when not the owner of the farm"))
 	}

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -282,3 +282,20 @@ func (f *FarmAPI) getFarmCustomPriceForThreebot(r *http.Request) (interface{}, m
 	return price, nil
 
 }
+
+func (f *FarmAPI) createOrUpdateFarmCustomPrice(r *http.Request) (interface{}, mw.Response) {
+
+	var postedFarmThreebotPrice directory.FarmThreebotPrice
+	if err := json.NewDecoder(r.Body).Decode(&postedFarmThreebotPrice); err != nil {
+		return nil, mw.BadRequest(err)
+	}
+
+	ctx := r.Context()
+
+	db := mw.Database(r)
+	price, err := f.GetFarmCustomPriceForThreebot(ctx, db, postedFarmThreebotPrice.FarmId, postedFarmThreebotPrice.ThreebotId)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+	return price, nil
+}

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/zaibon/httpsig"
 	"go.mongodb.org/mongo-driver/bson"
@@ -246,27 +247,58 @@ func (f *FarmAPI) getFarmCustomPrices(r *http.Request) (interface{}, mw.Response
 	// Get the farm from the middleware context
 	sid := mux.Vars(r)["farm_id"]
 
-	farmID, err := strconv.ParseInt(sid, 10, 64)
+	farmId, err := strconv.ParseInt(sid, 10, 64)
 	ctx := r.Context()
 
 	db := mw.Database(r)
-	prices, _, err := f.GetFarmCustomPrices(ctx, db, farmID)
+
+	if !f.isAuthenticated(r) {
+		return nil, mw.BadRequest(errors.Errorf("not authenticated"))
+
+	}
+	sauthenticatedThreebotCaller := r.Header.Get("Threebot-Id")
+	// if authenticated is not the farm owner or the threebot of the custom price we return bad request too.
+	authenticatedThreebotCallerId, err := strconv.ParseInt(sauthenticatedThreebotCaller, 10, 64)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	return prices, nil
+
+	farm, err := f.GetByID(ctx, db, farmId)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+	farmerId := farm.ThreebotId
+	prices, _, err := f.GetFarmCustomPrices(ctx, db, farmId)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+	if farmerId == authenticatedThreebotCallerId {
+		return prices, nil // return all of them
+	}
+	prices = nil // reset the slice
+	priceToReturn, err := f.GetFarmCustomPriceForThreebot(ctx, db, farmId, authenticatedThreebotCallerId)
+	if err != nil {
+		return prices, mw.Ok()
+	}
+	prices = append(prices, priceToReturn)
+	return prices, mw.Ok()
 }
 func (f *FarmAPI) getFarmCustomPriceForThreebot(r *http.Request) (interface{}, mw.Response) {
 	// Get the farm from the middleware context
 	sfid := mux.Vars(r)["farm_id"]
 	stid := mux.Vars(r)["threebot_id"]
 
-	farmID, err := strconv.ParseInt(sfid, 10, 64)
-	if err != nil {
-		return nil, mw.BadRequest(err)
+	if !f.isAuthenticated(r) {
+		return nil, mw.BadRequest(errors.Errorf("not authenticated"))
 
 	}
-	threebotID, err := strconv.ParseInt(stid, 10, 64)
+	sauthenticatedThreebotCaller := r.Header.Get("Threebot-Id")
+	// if authenticated is not the farm owner or the threebot of the custom price we return bad request too.
+	authenticatedThreebotCallerId, err := strconv.ParseInt(sauthenticatedThreebotCaller, 10, 64)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+	farmId, err := strconv.ParseInt(sfid, 10, 64)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 
@@ -274,10 +306,24 @@ func (f *FarmAPI) getFarmCustomPriceForThreebot(r *http.Request) (interface{}, m
 	ctx := r.Context()
 
 	db := mw.Database(r)
-	price, err := f.GetFarmCustomPriceForThreebot(ctx, db, farmID, threebotID)
+	farm, err := f.GetByID(ctx, db, farmId)
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
+	farmerId := farm.ThreebotId
+	threebotId, err := strconv.ParseInt(stid, 10, 64)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+	if authenticatedThreebotCallerId != threebotId && authenticatedThreebotCallerId != farmerId {
+		return nil, mw.BadRequest(errors.Errorf("not allowed to see that deal"))
+	}
+
+	price, err := f.GetFarmCustomPriceForThreebot(ctx, db, farmId, threebotId)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+
 	return price, nil
 
 }

--- a/pkg/directory/farms_store.go
+++ b/pkg/directory/farms_store.go
@@ -85,9 +85,10 @@ func (s FarmAPI) Delete(ctx context.Context, db *mongo.Database, id int64) error
 	return filter.Delete(ctx, db)
 }
 
-func (s *FarmAPI) GetFarmCustomPrices(ctx context.Context, db *mongo.Database, farmId int64) ([]directory.FarmThreebotPrice, int64, error) {
+// GetFarmCustomPrices gets the farm deals
+func (s *FarmAPI) GetFarmCustomPrices(ctx context.Context, db *mongo.Database, farmID int64) ([]directory.FarmThreebotPrice, int64, error) {
 	var filter directory.FarmThreebotPriceFilter
-	filter = filter.WithFarmID(farmId)
+	filter = filter.WithFarmID(farmID)
 	var count int64
 
 	cur, err := filter.Find(ctx, db)
@@ -109,13 +110,14 @@ func (s *FarmAPI) GetFarmCustomPrices(ctx context.Context, db *mongo.Database, f
 	return out, count, nil
 }
 
-func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.Database, farmId, threebotId int64) (directory.FarmThreebotPrice, error) {
+// GetFarmCustomPriceForThreebot gets a farm deal with a specific threebot
+func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.Database, farmID, threebotID int64) (directory.FarmThreebotPrice, error) {
 	var filter directory.FarmThreebotPriceFilter
-	filter = filter.WithFarmID(farmId).WithThreebotID(threebotId)
+	filter = filter.WithFarmID(farmID).WithThreebotID(threebotID)
 	farmThreebotPrice, err := filter.Get(ctx, db)
 	if err != nil {
 		// check the default pricing or return the explorer pricing..
-		farm, farmerr := s.GetByID(ctx, db, farmId)
+		farm, farmerr := s.GetByID(ctx, db, farmID)
 		if farmerr != nil {
 			return directory.FarmThreebotPrice{}, errors.Wrap(farmerr, "failed to find farm") //todo add farm id..
 		}
@@ -126,7 +128,7 @@ func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.D
 			unwrappedFromMongoFarmPrice.SU = farm.FarmCloudUnitsPrice.SU
 			unwrappedFromMongoFarmPrice.NU = farm.FarmCloudUnitsPrice.NU
 			unwrappedFromMongoFarmPrice.IPv4U = farm.FarmCloudUnitsPrice.IPv4U
-			return directory.FarmThreebotPrice{FarmId: farmId, ThreebotId: threebotId, CustomCloudUnitPrice: unwrappedFromMongoFarmPrice}, nil
+			return directory.FarmThreebotPrice{FarmID: farmID, ThreebotID: threebotID, CustomCloudUnitPrice: unwrappedFromMongoFarmPrice}, nil
 		}
 
 		return directory.FarmThreebotPrice{}, errors.Wrap(err, "farmer doesn't use custom pricing. should fallback to explorer generic calculation")
@@ -135,30 +137,31 @@ func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.D
 
 }
 
-func (s *FarmAPI) DeleteFarmThreebotCustomPrice(ctx context.Context, db *mongo.Database, farmId, threebotId int64) error {
+// DeleteFarmThreebotCustomPrice Delete FarmThreebotCustomPrice deletes a deal between farm and a threebot
+func (s *FarmAPI) DeleteFarmThreebotCustomPrice(ctx context.Context, db *mongo.Database, farmID, threebotID int64) error {
 	var filter directory.FarmThreebotPriceFilter
-	filter = filter.WithFarmID(farmId).WithThreebotID(threebotId)
+	filter = filter.WithFarmID(farmID).WithThreebotID(threebotID)
 	return filter.Delete(ctx, db)
 }
 
-// FarmThreebotPriceCreate creates a new farm threebot price
+// FarmThreebotPriceCreateOrUpdate creates or updates a new farm deal with a threebot
 func (s *FarmAPI) FarmThreebotPriceCreateOrUpdate(ctx context.Context, db *mongo.Database, farmThreebotPrice directory.FarmThreebotPrice) error {
 	// this to preven the farmer from overriding other managed fields
 	// like the list of IPs
 
 	update := struct {
-		ThreebotId           int64                        `bson:"threebot_id" json:"threebot_id"`
-		FarmId               int64                        `bson:"farm_id" json:"farm_id"`
+		ThreebotID           int64                        `bson:"threebot_id" json:"threebot_id"`
+		FarmID               int64                        `bson:"farm_id" json:"farm_id"`
 		CustomCloudUnitPrice generated.NodeCloudUnitPrice `bson:"custom_cloudunits_price" json:"custom_cloudunits_price"`
 	}{
-		ThreebotId:           farmThreebotPrice.ThreebotId,
-		FarmId:               farmThreebotPrice.FarmId,
+		ThreebotID:           farmThreebotPrice.ThreebotID,
+		FarmID:               farmThreebotPrice.FarmID,
 		CustomCloudUnitPrice: farmThreebotPrice.CustomCloudUnitPrice,
 	}
 	opts := options.Update().SetUpsert(true)
 
 	col := db.Collection(directory.FarmThreebotPriceCollection)
-	f := directory.FarmThreebotPriceFilter{}.WithFarmID(farmThreebotPrice.FarmId).WithThreebotID(farmThreebotPrice.ThreebotId)
+	f := directory.FarmThreebotPriceFilter{}.WithFarmID(farmThreebotPrice.FarmID).WithThreebotID(farmThreebotPrice.ThreebotID)
 	_, err := col.UpdateOne(ctx, f, bson.M{"$set": update}, opts)
 	return err
 }

--- a/pkg/directory/farms_store.go
+++ b/pkg/directory/farms_store.go
@@ -122,10 +122,10 @@ func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.D
 		if farm.EnableCustomPricing {
 			// is there a better way to unwrap the returned farm?
 			unwrappedFromMongoFarmPrice := generated.NodeCloudUnitPrice{}
-			unwrappedFromMongoFarmPrice.CU = farm.DefaultCloudUnitsPrice.CU
-			unwrappedFromMongoFarmPrice.SU = farm.DefaultCloudUnitsPrice.SU
-			unwrappedFromMongoFarmPrice.NU = farm.DefaultCloudUnitsPrice.NU
-			unwrappedFromMongoFarmPrice.IPv4U = farm.DefaultCloudUnitsPrice.IPv4U
+			unwrappedFromMongoFarmPrice.CU = farm.FarmCloudUnitsPrice.CU
+			unwrappedFromMongoFarmPrice.SU = farm.FarmCloudUnitsPrice.SU
+			unwrappedFromMongoFarmPrice.NU = farm.FarmCloudUnitsPrice.NU
+			unwrappedFromMongoFarmPrice.IPv4U = farm.FarmCloudUnitsPrice.IPv4U
 			return directory.FarmThreebotPrice{FarmId: farmId, ThreebotId: threebotId, CustomCloudUnitPrice: unwrappedFromMongoFarmPrice}, nil
 		}
 

--- a/pkg/directory/farms_store.go
+++ b/pkg/directory/farms_store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	generated "github.com/threefoldtech/tfexplorer/models/generated/directory"
 	directory "github.com/threefoldtech/tfexplorer/pkg/directory/types"
+
 	"github.com/threefoldtech/tfexplorer/schema"
 	"github.com/zaibon/httpsig"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -125,7 +126,8 @@ func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.D
 			unwrappedFromMongoFarmPrice.NU = farm.DefaultCloudUnitPrice.NU
 			return directory.FarmThreebotPrice{FarmId: farmId, ThreebotId: threebotId, CustomCloudUnitPrice: unwrappedFromMongoFarmPrice}, nil
 		}
-		return directory.FarmThreebotPrice{FarmId: farmId, ThreebotId: threebotId, CustomCloudUnitPrice: generated.NewNodeCloudUnitPrice()}, nil
+
+		return directory.FarmThreebotPrice{}, errors.Wrap(err, "farmer doesn't use custom pricing. should fallback to explorer generic calculation")
 	}
 	return farmThreebotPrice, nil
 }

--- a/pkg/directory/farms_store.go
+++ b/pkg/directory/farms_store.go
@@ -110,7 +110,7 @@ func (s *FarmAPI) GetFarmCustomPrices(ctx context.Context, db *mongo.Database, f
 func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.Database, farmId, threebotId int64) (directory.FarmThreebotPrice, error) {
 	var filter directory.FarmThreebotPriceFilter
 	filter = filter.WithFarmID(farmId).WithThreebotID(threebotId)
-	price, err := filter.Get(ctx, db)
+	farmThreebotPrice, err := filter.Get(ctx, db)
 	if err != nil {
 		// check the default pricing or return the explorer pricing..
 		farm, err := s.GetByID(ctx, db, farmId)
@@ -124,12 +124,9 @@ func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.D
 			unwrappedFromMongoFarmPrice.CU = farm.DefaultCloudUnitPrice.CU
 			unwrappedFromMongoFarmPrice.SU = farm.DefaultCloudUnitPrice.SU
 			unwrappedFromMongoFarmPrice.NU = farm.DefaultCloudUnitPrice.NU
-
 			return directory.FarmThreebotPrice{FarmId: farmId, ThreebotId: threebotId, CustomCloudUnitPrice: unwrappedFromMongoFarmPrice}, nil
-		} else {
-			return directory.FarmThreebotPrice{FarmId: farmId, ThreebotId: threebotId, CustomCloudUnitPrice: generated.NewNodeCloudUnitPrice()}, nil
-
 		}
+		return directory.FarmThreebotPrice{FarmId: farmId, ThreebotId: threebotId, CustomCloudUnitPrice: generated.NewNodeCloudUnitPrice()}, nil
 	}
-	return price, nil
+	return farmThreebotPrice, nil
 }

--- a/pkg/directory/farms_store.go
+++ b/pkg/directory/farms_store.go
@@ -117,10 +117,9 @@ func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.D
 		if err != nil {
 			return directory.FarmThreebotPrice{}, errors.Wrap(err, "failed to find farm") //todo add farm id..
 		}
-		if farm.DefaultCloudUnitPrice.EnableCustomPricing {
+		if farm.EnableCustomPricing {
 			// is there a better way to unwrap the returned farm?
 			unwrappedFromMongoFarmPrice := generated.NodeCloudUnitPrice{}
-			unwrappedFromMongoFarmPrice.EnableCustomPricing = farm.DefaultCloudUnitPrice.EnableCustomPricing
 			unwrappedFromMongoFarmPrice.CU = farm.DefaultCloudUnitPrice.CU
 			unwrappedFromMongoFarmPrice.SU = farm.DefaultCloudUnitPrice.SU
 			unwrappedFromMongoFarmPrice.NU = farm.DefaultCloudUnitPrice.NU

--- a/pkg/directory/farms_store.go
+++ b/pkg/directory/farms_store.go
@@ -131,3 +131,9 @@ func (s *FarmAPI) GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.D
 	}
 	return farmThreebotPrice, nil
 }
+
+func (s *FarmAPI) DeleteFarmThreebotCustomPrice(ctx context.Context, db *mongo.Database, farmId, threebotId int64) error {
+	var filter directory.FarmThreebotPriceFilter
+	filter = filter.WithFarmID(farmId).WithThreebotID(threebotId)
+	return filter.Delete(ctx, db)
+}

--- a/pkg/directory/node_handlers.go
+++ b/pkg/directory/node_handlers.go
@@ -321,7 +321,7 @@ func farmOwner(ctx context.Context, farmID int64, db *mongo.Database) (int64, mw
 		return 0, mw.Error(err) //TODO
 	}
 
-	return farm.ThreebotId, nil
+	return farm.ThreebotID, nil
 }
 
 // isFarmerAuthorized ensure it is the farmer authenticated in request r is owning the node

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -31,10 +31,8 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farms.HandleFunc("", mw.AsHandlerFunc(farmAPI.registerFarm)).Methods("POST").Name("farm-register-v1")
 	farms.HandleFunc("", mw.AsHandlerFunc(farmAPI.listFarm)).Methods("GET").Name("farm-list-v1")
 	farms.HandleFunc("/{farm_id}", mw.AsHandlerFunc(farmAPI.getFarm)).Methods("GET").Name("farm-get-v1")
-	farms.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.getFarmCustomPrices)).Methods("GET").Name("farm-get-prices-v1")
-	farms.HandleFunc("/{farm_id}/custom_prices/{threebot_id}", mw.AsHandlerFunc(farmAPI.getFarmCustomPriceForThreebot)).Methods("GET").Name("farm-get-prices-for-threebot-v1")
-	farms.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
-	farms.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
+	farms.HandleFunc("/{farm_id}/deals", mw.AsHandlerFunc(farmAPI.getFarmCustomPrices)).Methods("GET").Name("farm-get-prices-v1")
+	farms.HandleFunc("/{farm_id}/deals/{threebot_id}", mw.AsHandlerFunc(farmAPI.getFarmCustomPriceForThreebot)).Methods("GET").Name("farm-get-prices-for-threebot-v1")
 
 	farmsAuthenticated := farms.PathPrefix("/{farm_id}").Subrouter()
 	farmsAuthenticated.Use(mw.NewAuthMiddleware(userVerifier).Middleware)
@@ -43,6 +41,8 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("/ip", mw.AsHandlerFunc(farmAPI.deleteFarmIps)).Methods("DELETE").Name("farm-delete-ip-v1")
 	farmsAuthenticated.HandleFunc("", mw.AsHandlerFunc(farmAPI.updateFarm)).Methods("PUT").Name("farm-update-v1")
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
+	farmsAuthenticated.HandleFunc("/deals", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
+	farmsAuthenticated.HandleFunc("/deals", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
 
 	nodes := api.PathPrefix("/nodes").Subrouter()
 	nodesAuthenticated := api.PathPrefix("/nodes").Subrouter()

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -31,6 +31,10 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farms.HandleFunc("", mw.AsHandlerFunc(farmAPI.registerFarm)).Methods("POST").Name("farm-register-v1")
 	farms.HandleFunc("", mw.AsHandlerFunc(farmAPI.listFarm)).Methods("GET").Name("farm-list-v1")
 	farms.HandleFunc("/{farm_id}", mw.AsHandlerFunc(farmAPI.getFarm)).Methods("GET").Name("farm-get-v1")
+	farms.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.getFarmCustomPrices)).Methods("GET").Name("farm-get-prices-v1")
+	farms.HandleFunc("/{farm_id}/custom_prices/{threebot_id}", mw.AsHandlerFunc(farmAPI.getFarmCustomPriceForThreebot)).Methods("GET").Name("farm-get-prices-for-threebot-v1")
+	farms.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
+	farms.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
 
 	farmsAuthenticated := farms.PathPrefix("/{farm_id}").Subrouter()
 	farmsAuthenticated.Use(mw.NewAuthMiddleware(userVerifier).Middleware)
@@ -39,9 +43,6 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("/ip", mw.AsHandlerFunc(farmAPI.deleteFarmIps)).Methods("DELETE").Name("farm-delete-ip-v1")
 	farmsAuthenticated.HandleFunc("", mw.AsHandlerFunc(farmAPI.updateFarm)).Methods("PUT").Name("farm-update-v1")
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
-	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.getFarmCustomPrices)).Methods("GET").Name("farm-get-prices-v1")
-	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
-	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
 
 	nodes := api.PathPrefix("/nodes").Subrouter()
 	nodesAuthenticated := api.PathPrefix("/nodes").Subrouter()

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -41,6 +41,7 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
 	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.getFarmCustomPrices)).Methods("GET").Name("farm-get-prices-v1")
 	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
+	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
 
 	nodes := api.PathPrefix("/nodes").Subrouter()
 	nodesAuthenticated := api.PathPrefix("/nodes").Subrouter()

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -39,6 +39,7 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("/ip", mw.AsHandlerFunc(farmAPI.deleteFarmIps)).Methods("DELETE").Name("farm-delete-ip-v1")
 	farmsAuthenticated.HandleFunc("", mw.AsHandlerFunc(farmAPI.updateFarm)).Methods("PUT").Name("farm-update-v1")
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
+	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.getFarmCustomPrices)).Methods("GET").Name("farm-get-prices-v1")
 
 	nodes := api.PathPrefix("/nodes").Subrouter()
 	nodesAuthenticated := api.PathPrefix("/nodes").Subrouter()

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -40,6 +40,7 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("", mw.AsHandlerFunc(farmAPI.updateFarm)).Methods("PUT").Name("farm-update-v1")
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
 	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.getFarmCustomPrices)).Methods("GET").Name("farm-get-prices-v1")
+	farmsAuthenticated.HandleFunc("/{farm_id}/custom_prices", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
 
 	nodes := api.PathPrefix("/nodes").Subrouter()
 	nodesAuthenticated := api.PathPrefix("/nodes").Subrouter()

--- a/pkg/directory/types/farm.go
+++ b/pkg/directory/types/farm.go
@@ -209,27 +209,27 @@ func FarmUpdate(ctx context.Context, db *mongo.Database, id schema.ID, farm Farm
 	// this to preven the farmer from overriding other managed fields
 	// like the list of IPs
 	update := struct {
-		ThreebotID             int64                         `bson:"threebot_id" json:"threebot_id"`
-		IyoOrganization        string                        `bson:"iyo_organization" json:"iyo_organization"`
-		Name                   string                        `bson:"name" json:"name"`
-		WalletAddresses        []generated.WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
-		Location               generated.Location            `bson:"location" json:"location"`
-		Email                  schema.Email                  `bson:"email" json:"email"`
-		ResourcePrices         []generated.NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
-		PrefixZero             schema.IPRange                `bson:"prefix_zero" json:"prefix_zero"`
-		EnableCustomPricing    bool                          `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
-		DefaultCloudUnitsPrice generated.NodeCloudUnitPrice  `bson:"default_cloudunits_price" json:"default_cloudunits_price"`
+		ThreebotID          int64                         `bson:"threebot_id" json:"threebot_id"`
+		IyoOrganization     string                        `bson:"iyo_organization" json:"iyo_organization"`
+		Name                string                        `bson:"name" json:"name"`
+		WalletAddresses     []generated.WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
+		Location            generated.Location            `bson:"location" json:"location"`
+		Email               schema.Email                  `bson:"email" json:"email"`
+		ResourcePrices      []generated.NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
+		PrefixZero          schema.IPRange                `bson:"prefix_zero" json:"prefix_zero"`
+		EnableCustomPricing bool                          `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
+		FarmCloudUnitsPrice generated.NodeCloudUnitPrice  `bson:"farm_cloudunits_price" json:"default_cloudunits_price"`
 	}{
-		ThreebotID:             farm.ThreebotId,
-		IyoOrganization:        farm.IyoOrganization,
-		Name:                   farm.Name,
-		WalletAddresses:        farm.WalletAddresses,
-		Location:               farm.Location,
-		Email:                  farm.Email,
-		ResourcePrices:         farm.ResourcePrices,
-		PrefixZero:             farm.PrefixZero,
-		EnableCustomPricing:    farm.EnableCustomPricing,
-		DefaultCloudUnitsPrice: farm.DefaultCloudUnitsPrice,
+		ThreebotID:          farm.ThreebotId,
+		IyoOrganization:     farm.IyoOrganization,
+		Name:                farm.Name,
+		WalletAddresses:     farm.WalletAddresses,
+		Location:            farm.Location,
+		Email:               farm.Email,
+		ResourcePrices:      farm.ResourcePrices,
+		PrefixZero:          farm.PrefixZero,
+		EnableCustomPricing: farm.EnableCustomPricing,
+		FarmCloudUnitsPrice: farm.FarmCloudUnitsPrice,
 	}
 
 	col := db.Collection(FarmCollection)

--- a/pkg/directory/types/farm.go
+++ b/pkg/directory/types/farm.go
@@ -38,7 +38,7 @@ func (f *Farm) Validate() error {
 		return fmt.Errorf("invalid farm name. name can only contain alphanumeric characters dash (-) or underscore (_)")
 	}
 
-	if f.ThreebotId == 0 {
+	if f.ThreebotID == 0 {
 		return fmt.Errorf("threebot_id is required")
 	}
 
@@ -220,7 +220,7 @@ func FarmUpdate(ctx context.Context, db *mongo.Database, id schema.ID, farm Farm
 		EnableCustomPricing bool                          `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
 		FarmCloudUnitsPrice generated.NodeCloudUnitPrice  `bson:"farm_cloudunits_price" json:"default_cloudunits_price"`
 	}{
-		ThreebotID:          farm.ThreebotId,
+		ThreebotID:          farm.ThreebotID,
 		IyoOrganization:     farm.IyoOrganization,
 		Name:                farm.Name,
 		WalletAddresses:     farm.WalletAddresses,

--- a/pkg/directory/types/farm.go
+++ b/pkg/directory/types/farm.go
@@ -209,23 +209,27 @@ func FarmUpdate(ctx context.Context, db *mongo.Database, id schema.ID, farm Farm
 	// this to preven the farmer from overriding other managed fields
 	// like the list of IPs
 	update := struct {
-		ThreebotID      int64                         `bson:"threebot_id" json:"threebot_id"`
-		IyoOrganization string                        `bson:"iyo_organization" json:"iyo_organization"`
-		Name            string                        `bson:"name" json:"name"`
-		WalletAddresses []generated.WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
-		Location        generated.Location            `bson:"location" json:"location"`
-		Email           schema.Email                  `bson:"email" json:"email"`
-		ResourcePrices  []generated.NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
-		PrefixZero      schema.IPRange                `bson:"prefix_zero" json:"prefix_zero"`
+		ThreebotID             int64                         `bson:"threebot_id" json:"threebot_id"`
+		IyoOrganization        string                        `bson:"iyo_organization" json:"iyo_organization"`
+		Name                   string                        `bson:"name" json:"name"`
+		WalletAddresses        []generated.WalletAddress     `bson:"wallet_addresses" json:"wallet_addresses"`
+		Location               generated.Location            `bson:"location" json:"location"`
+		Email                  schema.Email                  `bson:"email" json:"email"`
+		ResourcePrices         []generated.NodeResourcePrice `bson:"resource_prices" json:"resource_prices"`
+		PrefixZero             schema.IPRange                `bson:"prefix_zero" json:"prefix_zero"`
+		EnableCustomPricing    bool                          `bson:"enable_custom_pricing" json:"enable_custom_pricing"`
+		DefaultCloudUnitsPrice generated.NodeCloudUnitPrice  `bson:"default_cloudunits_price" json:"default_cloudunits_price"`
 	}{
-		ThreebotID:      farm.ThreebotId,
-		IyoOrganization: farm.IyoOrganization,
-		Name:            farm.Name,
-		WalletAddresses: farm.WalletAddresses,
-		Location:        farm.Location,
-		Email:           farm.Email,
-		ResourcePrices:  farm.ResourcePrices,
-		PrefixZero:      farm.PrefixZero,
+		ThreebotID:             farm.ThreebotId,
+		IyoOrganization:        farm.IyoOrganization,
+		Name:                   farm.Name,
+		WalletAddresses:        farm.WalletAddresses,
+		Location:               farm.Location,
+		Email:                  farm.Email,
+		ResourcePrices:         farm.ResourcePrices,
+		PrefixZero:             farm.PrefixZero,
+		EnableCustomPricing:    farm.EnableCustomPricing,
+		DefaultCloudUnitsPrice: farm.DefaultCloudUnitsPrice,
 	}
 
 	col := db.Collection(FarmCollection)

--- a/pkg/directory/types/farmthreebotprice.go
+++ b/pkg/directory/types/farmthreebotprice.go
@@ -16,26 +16,26 @@ import (
 )
 
 const (
-	// FarmCollection db collection name
+	// FarmThreebotPriceCollection db collection name
 	FarmThreebotPriceCollection = "farmthreebotprice"
 )
 
-//Farm mongo db wrapper for generated TfgridDirectoryFarm
+// FarmThreebotPrice mongo db wrapper for generated TfgridDirectoryFarm
 type FarmThreebotPrice generated.FarmThreebotPrice
 
 // Validate validates farm object
 func (f *FarmThreebotPrice) Validate() error {
-	if f.ThreebotId == 0 {
+	if f.ThreebotID == 0 {
 		return fmt.Errorf("threebot_id is required")
 	}
-	if f.FarmId == 0 {
+	if f.FarmID == 0 {
 		return fmt.Errorf("farm_id is required")
 	}
 
 	return nil
 }
 
-// FarmQuery helper to parse query string
+// FarmThreebotPriceQuery helper to parse query string
 type FarmThreebotPriceQuery struct {
 	FarmID     int64
 	ThreebotID int64

--- a/pkg/directory/types/farmthreebotprice.go
+++ b/pkg/directory/types/farmthreebotprice.go
@@ -114,29 +114,3 @@ func (f FarmThreebotPriceFilter) Delete(ctx context.Context, db *mongo.Database)
 	_, err = col.DeleteOne(ctx, f, options.Delete())
 	return err
 }
-
-// FarmThreebotPriceCreate creates a new farm threebot price
-func FarmThreebotPriceCreateOrUpdate(ctx context.Context, db *mongo.Database, farmThreebotPrice FarmThreebotPrice) error {
-	if err := farmThreebotPrice.Validate(); err != nil {
-		return err
-	}
-	// update is a subset of Farm that only has the updatable fields.
-	// this to preven the farmer from overriding other managed fields
-	// like the list of IPs
-
-	update := struct {
-		ThreebotId           int64                        `bson:"threebot_id" json:"threebot_id"`
-		FarmId               int64                        `bson:"farm_id" json:"farm_id"`
-		CustomCloudUnitPrice generated.NodeCloudUnitPrice `bson:"custom_cloud_unit_price" json:"custom_cloud_unit_price"`
-	}{
-		ThreebotId:           farmThreebotPrice.ThreebotId,
-		FarmId:               farmThreebotPrice.FarmId,
-		CustomCloudUnitPrice: farmThreebotPrice.CustomCloudUnitPrice,
-	}
-	opts := options.Update().SetUpsert(true)
-
-	col := db.Collection(FarmThreebotPriceCollection)
-	f := FarmThreebotPriceFilter{}.WithFarmID(farmThreebotPrice.FarmId).WithThreebotID(farmThreebotPrice.ThreebotId)
-	_, err := col.UpdateOne(ctx, f, bson.M{"$set": update}, opts)
-	return err
-}

--- a/pkg/directory/types/farmthreebotprice.go
+++ b/pkg/directory/types/farmthreebotprice.go
@@ -1,0 +1,162 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/tfexplorer/models"
+	generated "github.com/threefoldtech/tfexplorer/models/generated/directory"
+
+	"github.com/threefoldtech/tfexplorer/mw"
+	"github.com/threefoldtech/tfexplorer/schema"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const (
+	// FarmCollection db collection name
+	FarmThreebotPriceCollection = "farmthreebotprice"
+)
+
+//Farm mongo db wrapper for generated TfgridDirectoryFarm
+type FarmThreebotPrice generated.FarmThreebotPrice
+
+// Validate validates farm object
+func (f *FarmThreebotPrice) Validate() error {
+	if f.ThreebotId == 0 {
+		return fmt.Errorf("threebot_id is required")
+	}
+	if f.FarmId == 0 {
+		return fmt.Errorf("farm_id is required")
+	}
+
+	return nil
+}
+
+// FarmQuery helper to parse query string
+type FarmThreebotPriceQuery struct {
+	FarmID     int64
+	ThreebotID int64
+}
+
+// Parse querystring from request
+func (f *FarmThreebotPriceQuery) Parse(r *http.Request) mw.Response {
+	var err error
+	f.ThreebotID, err = models.QueryInt(r, "threebot_id")
+	if err != nil {
+		return mw.BadRequest(errors.Wrap(err, "threebot_id should be a integer"))
+	}
+	f.FarmID, err = models.QueryInt(r, "farm_id")
+	if err != nil {
+		return mw.BadRequest(errors.Wrap(err, "farm_id should be a integer"))
+	}
+	return nil
+}
+
+// FarmThreebotPriceFilter type
+type FarmThreebotPriceFilter bson.D
+
+// WithFarmID filter farm with ID
+func (f FarmThreebotPriceFilter) WithFarmID(id int64) FarmThreebotPriceFilter {
+	return append(f, bson.E{Key: "farm_id", Value: id})
+}
+
+// WithThreebotID filter threebot with ID
+func (f FarmThreebotPriceFilter) WithThreebotID(id int64) FarmThreebotPriceFilter {
+	return append(f, bson.E{Key: "threebot_id", Value: id})
+}
+
+// Find run the filter and return a cursor result
+func (f FarmThreebotPriceFilter) Find(ctx context.Context, db *mongo.Database, opts ...*options.FindOptions) (*mongo.Cursor, error) {
+	col := db.Collection(FarmThreebotPriceCollection)
+	if f == nil {
+		f = FarmThreebotPriceFilter{}
+	}
+
+	return col.Find(ctx, f, opts...)
+}
+
+// Count number of documents matching
+func (f FarmThreebotPriceFilter) Count(ctx context.Context, db *mongo.Database) (int64, error) {
+	col := db.Collection(FarmCollection)
+	if f == nil {
+		f = FarmThreebotPriceFilter{}
+	}
+
+	return col.CountDocuments(ctx, f)
+}
+
+// Get one farm that matches the filter
+func (f FarmThreebotPriceFilter) Get(ctx context.Context, db *mongo.Database) (farmThreebotPrice FarmThreebotPrice, err error) {
+	if f == nil {
+		f = FarmThreebotPriceFilter{}
+	}
+	col := db.Collection(FarmThreebotPriceCollection)
+	result := col.FindOne(ctx, f, options.FindOne())
+
+	err = result.Err()
+	if err != nil {
+		return
+	}
+
+	err = result.Decode(&farmThreebotPrice)
+	return
+}
+
+// Delete deletes one farm that match the filter
+func (f FarmThreebotPriceFilter) Delete(ctx context.Context, db *mongo.Database) (err error) {
+	if f == nil {
+		f = FarmThreebotPriceFilter{}
+	}
+	col := db.Collection(FarmThreebotPriceCollection)
+	_, err = col.DeleteOne(ctx, f, options.Delete())
+	return err
+}
+
+// FarmThreebotPriceCreate creates a new farm threebot price
+func FarmThreebotPriceCreate(ctx context.Context, db *mongo.Database, farmThreebotPrice FarmThreebotPrice) (schema.ID, error) {
+	if err := farmThreebotPrice.Validate(); err != nil {
+		return 0, err
+	}
+
+	col := db.Collection(FarmThreebotPriceCollection)
+	id, err := models.NextID(ctx, db, FarmThreebotPriceCollection)
+	if err != nil {
+		return id, err
+	}
+
+	farmThreebotPrice.ID = id
+	_, err = col.InsertOne(ctx, farmThreebotPrice)
+	return id, err
+}
+
+// FarmThreebotPriceUpdate update an existing farm threebot price
+func FarmThreebotPriceUpdate(ctx context.Context, db *mongo.Database, id schema.ID, farmThreebotPrice FarmThreebotPrice) error {
+	farmThreebotPrice.ID = id
+
+	if err := farmThreebotPrice.Validate(); err != nil {
+		return err
+	}
+
+	// update is a subset of Farm that only has the updatable fields.
+	// this to preven the farmer from overriding other managed fields
+	// like the list of IPs
+
+	update := struct {
+		ThreebotId           int64                        `bson:"threebot_id" json:"threebot_id"`
+		FarmId               int64                        `bson:"farm_id" json:"farm_id"`
+		CustomCloudUnitPrice generated.NodeCloudUnitPrice `bson:"custom_cloud_unit_price" json:"custom_cloud_unit_price"`
+	}{
+		ThreebotId:           farmThreebotPrice.ThreebotId,
+		FarmId:               farmThreebotPrice.FarmId,
+		CustomCloudUnitPrice: farmThreebotPrice.CustomCloudUnitPrice,
+	}
+
+	col := db.Collection(FarmThreebotPriceCollection)
+	f := FarmThreebotPriceFilter{}.WithFarmID(farmThreebotPrice.FarmId).WithThreebotID(farmThreebotPrice.ThreebotId)
+	_, err := col.UpdateOne(ctx, f, bson.M{"$set": update})
+	return err
+}

--- a/pkg/directory/types/setup.go
+++ b/pkg/directory/types/setup.go
@@ -36,6 +36,16 @@ func Setup(ctx context.Context, db *mongo.Database) error {
 		},
 	}
 
+	farmThreebotPrice := db.Collection(FarmThreebotPriceCollection)
+	farmThreebotPriceIndexes := []mongo.IndexModel{
+		{
+			Keys: bson.M{"farm_id": 1},
+		},
+		{
+			Keys: bson.M{"threebot_id": 1},
+		},
+	}
+
 	for _, x := range []string{"total_resources", "user_resources", "reserved_resources"} {
 		for _, y := range []string{"cru", "mru", "hru", "sru"} {
 			nodeIdexes = append(nodeIdexes, mongo.IndexModel{
@@ -50,5 +60,10 @@ func Setup(ctx context.Context, db *mongo.Database) error {
 		log.Error().Err(err).Msg("failed to initialize node index")
 	}
 
+	_, err = farmThreebotPrice.Indexes().CreateMany(ctx, farmThreebotPriceIndexes)
+
+	if err != nil {
+		log.Error().Err(err).Msg("failed to initialize node index")
+	}
 	return err
 }

--- a/pkg/escrow/resource.go
+++ b/pkg/escrow/resource.go
@@ -95,8 +95,8 @@ func (e Stellar) calculateCustomCapacityReservationCost(CUs, SUs, IPv4Us uint64,
 	ipuCost := big.NewInt(0)
 
 	cuSecondTFTStropesCost := getComputeUnitSecondTFTStropesCost(cuDollarPerMonth)
-	suSecondTFTStropesCost := getComputeUnitSecondTFTStropesCost(suDollarPerMonth)
-	ip4uSecondTFTStropesCost := getComputeUnitSecondTFTStropesCost(ip4uDollarPerMonth)
+	suSecondTFTStropesCost := getStorageUnitSecondTFTStropesCost(suDollarPerMonth)
+	ip4uSecondTFTStropesCost := getIPv4UnitSecondTFTStropesCost(ip4uDollarPerMonth)
 
 	cuCost = cuCost.Mul(big.NewInt(cuSecondTFTStropesCost), big.NewInt(int64(CUs)))
 	suCost = suCost.Mul(big.NewInt(suSecondTFTStropesCost), big.NewInt(int64(SUs)))

--- a/pkg/escrow/stellar.go
+++ b/pkg/escrow/stellar.go
@@ -61,7 +61,7 @@ type (
 	FarmAPI interface {
 		// GetByID get a farm from the database using its ID
 		GetByID(ctx context.Context, db *mongo.Database, id int64) (directorytypes.Farm, error)
-		GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.Database, farmId, threebotId int64) (directorytypes.FarmThreebotPrice, error)
+		GetFarmCustomPriceForThreebot(ctx context.Context, db *mongo.Database, farmID, threebotID int64) (directorytypes.FarmThreebotPrice, error)
 	}
 
 	reservationRegisterJob struct {
@@ -557,6 +557,9 @@ func (e *Stellar) processCapacityReservation(reservation capacitytypes.Reservati
 	}
 
 	price, err := e.farmAPI.GetFarmCustomPriceForThreebot(e.ctx, e.db, farmIDs[0], reservation.SponsorTid)
+	if err != nil {
+		return customerInfo, errors.Wrap(err, "couldn't get price for threebot")
+	}
 	cuDollarPerMonth := price.CustomCloudUnitPrice.CU
 	suDollarPerMonth := price.CustomCloudUnitPrice.SU
 	ip4uDollarPerMonth := price.CustomCloudUnitPrice.IPv4U

--- a/pkg/escrow/stellar.go
+++ b/pkg/escrow/stellar.go
@@ -19,6 +19,7 @@ import (
 	"github.com/threefoldtech/tfexplorer/pkg/gridnetworks"
 	"github.com/threefoldtech/tfexplorer/pkg/stellar"
 	workloadtypes "github.com/threefoldtech/tfexplorer/pkg/workloads/types"
+
 	"github.com/threefoldtech/tfexplorer/schema"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -557,11 +558,15 @@ func (e *Stellar) processCapacityReservation(reservation capacitytypes.Reservati
 	}
 	var amount xdr.Int64
 	whichThreebotID := reservation.CustomerTid
-	if reservation.SponsorTid != 0 {
-		// should verify the sponsor here..
-		whichThreebotID = reservation.SponsorTid
+	poolID := reservation.DataReservation.PoolID
+	pool, err := capacitytypes.GetPool(e.ctx, e.db, schema.ID(poolID))
+	if err == nil {
+		whichThreebotID = pool.SponsorTid
+	} else {
+		if reservation.SponsorTid != 0 {
+			whichThreebotID = reservation.SponsorTid
+		}
 	}
-
 	price, err := e.farmAPI.GetFarmCustomPriceForThreebot(e.ctx, e.db, farmIDs[0], whichThreebotID)
 	// safe to ignore the error here, we already have a farm
 	if err != nil {

--- a/pkg/escrow/stellar.go
+++ b/pkg/escrow/stellar.go
@@ -559,7 +559,7 @@ func (e *Stellar) processCapacityReservation(reservation capacitytypes.Reservati
 	price, err := e.farmAPI.GetFarmCustomPriceForThreebot(e.ctx, e.db, farmIDs[0], reservation.SponsorTid)
 	cuDollarPerMonth := price.CustomCloudUnitPrice.CU
 	suDollarPerMonth := price.CustomCloudUnitPrice.SU
-	ip4uDollarPerMonth := price.CustomCloudUnitPrice.IP4U
+	ip4uDollarPerMonth := price.CustomCloudUnitPrice.IPv4U
 
 	amount, err := e.calculateCustomCapacityReservationCost(reservation.DataReservation.CUs, reservation.DataReservation.SUs, reservation.DataReservation.IPv4Us, cuDollarPerMonth, suDollarPerMonth, ip4uDollarPerMonth, node.FarmId)
 	if err != nil {

--- a/pkg/workloads/conversion.go
+++ b/pkg/workloads/conversion.go
@@ -94,7 +94,7 @@ func (a *API) getConversionList(r *http.Request) (interface{}, mw.Response) {
 			return nil, mw.Error(err)
 		}
 		// create pool
-		pool := capacitytypes.NewPool(0, userTid, nodeIDs)
+		pool := capacitytypes.NewPool(0, userTid, 0, nodeIDs)
 		pool, err = capacitytypes.CapacityPoolCreate(r.Context(), db, pool)
 		if err != nil {
 			return nil, mw.Error(err)

--- a/pkg/workloads/reservation.go
+++ b/pkg/workloads/reservation.go
@@ -251,16 +251,19 @@ func (a *API) setupPool(r *http.Request) (interface{}, mw.Response) {
 	if err := reservation.Verify(user.Pubkey); err != nil {
 		return nil, mw.BadRequest(errors.Wrap(err, "failed to verify customer signature"))
 	}
-
 	// sponsor filter
+
 	if reservation.SponsorTid != 0 {
+		if len(reservation.SponsorSignature) == 0 {
+			return nil, mw.BadRequest(errors.Wrapf(err, "cannot use sponsor_tid without providing sponsor_signature"))
+		}
+		filter = phonebook.UserFilter{}
 		filter = filter.WithID(schema.ID(reservation.SponsorTid))
 		sponsor, err := filter.Get(r.Context(), db)
 		if err != nil {
-			return nil, mw.BadRequest(errors.Wrapf(err, "cannot find user with id '%d'", reservation.SponsorTid))
+			return nil, mw.BadRequest(errors.Wrapf(err, "cannot find sponsor with id '%d'", reservation.SponsorTid))
 		}
-
-		if err := reservation.Verify(sponsor.Pubkey); err != nil {
+		if err := reservation.VerifySponsor(sponsor.Pubkey); err != nil {
 			return nil, mw.BadRequest(errors.Wrap(err, "failed to verify sponsor signature"))
 		}
 


### PR DESCRIPTION
This PR should fix #277 

- updating the generated/directory models with NodeCloudUnitPrice 
- set default pricing on the farm as option (defaults to zero value to allow falling back to explorer pricing)
- define type FarmThreebotPrice and model interaction list, find, filters
- Adds deals endpoints (get/create/update/delete)
- Adds sponsorTid, sponsorSignature to be able to apply deals when processing capacity reservation

also fixes #287 