### PR TITLE
feat: add field that dedicates a node to a certain user

### DIFF
--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -114,6 +114,8 @@ type Node struct {
 	WgPorts           []int64        `bson:"wg_ports" json:"wg_ports"`
 	Deleted           bool           `bson:"deleted" json:"deleted"`
 	Reserved          bool           `bson:"reserved" json:"reserved"`
+	// optional flag to indicate that a node can only accept workloads from a certain user
+	UserID schema.ID `bson:"user_id" json:"user_id"`
 }
 
 func NewNode() (Node, error) {

--- a/models/generated/directory/directory.go
+++ b/models/generated/directory/directory.go
@@ -115,7 +115,7 @@ type Node struct {
 	Deleted           bool           `bson:"deleted" json:"deleted"`
 	Reserved          bool           `bson:"reserved" json:"reserved"`
 	// optional flag to indicate that a node can only accept workloads from a certain user
-	UserID schema.ID `bson:"user_id" json:"user_id"`
+	Dedicated schema.ID `bson:"dedicated" json:"dedicated"`
 }
 
 func NewNode() (Node, error) {

--- a/models/generated/workloads/reservation.go
+++ b/models/generated/workloads/reservation.go
@@ -146,6 +146,17 @@ const (
 	WorkloadTypePublicIP
 )
 
+// Any returns true if the type is one of the given types
+func (t WorkloadTypeEnum) Any(types ...WorkloadTypeEnum) bool {
+	for _, typ := range types {
+		if typ == t {
+			return true
+		}
+	}
+
+	return false
+}
+
 // WorkloadTypes is a map of all the supported workload type
 var WorkloadTypes = map[WorkloadTypeEnum]string{
 	WorkloadTypeZDB:             "zdb",
@@ -168,4 +179,24 @@ func (e WorkloadTypeEnum) String() string {
 		return "UNKNOWN"
 	}
 	return s
+}
+
+// GatewayTypes is a list of all types processed by a gateway
+var GatewayTypes = []WorkloadTypeEnum{
+	WorkloadTypeProxy,
+	WorkloadTypeReverseProxy,
+	WorkloadTypeSubDomain,
+	WorkloadTypeDomainDelegate,
+	WorkloadTypeGateway4To6,
+}
+
+// ZeroOSTypes is a list of all types supported by zero-os node
+var ZeroOSTypes = []WorkloadTypeEnum{
+	WorkloadTypeZDB,
+	WorkloadTypeContainer,
+	WorkloadTypeVolume,
+	WorkloadTypeNetwork,
+	WorkloadTypeKubernetes,
+	WorkloadTypeNetworkResource,
+	WorkloadTypePublicIP,
 }

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/threefoldtech/tfexplorer/models"
 	"github.com/threefoldtech/tfexplorer/mw"
 	directory "github.com/threefoldtech/tfexplorer/pkg/directory/types"
+	phonebook "github.com/threefoldtech/tfexplorer/pkg/phonebook/types"
 	"github.com/threefoldtech/tfexplorer/schema"
 
 	"github.com/gorilla/mux"
@@ -145,6 +146,51 @@ func (f *FarmAPI) deleteNodeFromFarm(r *http.Request) (interface{}, mw.Response)
 	}
 
 	err = nodeAPI.Delete(r.Context(), db, nodeID)
+	if err != nil {
+		return nil, mw.Error(err)
+	}
+
+	return nil, mw.Ok()
+}
+
+func (f *FarmAPI) setNodeDedicated(r *http.Request) (interface{}, mw.Response) {
+	farmID := getFarmID(r.Context())
+
+	type body struct {
+		nodeID string
+		userID int64
+	}
+	var data body
+
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		return nil, mw.BadRequest(err)
+	}
+
+	var nodeAPI NodeAPI
+
+	db := mw.Database(r)
+	node, err := nodeAPI.Get(r.Context(), db, data.nodeID, false)
+	if err != nil {
+		return nil, mw.NotFound(err)
+	}
+
+	if node.FarmId != int64(farmID) {
+		return nil, mw.Forbidden(fmt.Errorf("only the farm owner of this node can update this node"))
+	}
+
+	var filter phonebook.UserFilter
+	filter = filter.WithID(schema.ID(data.userID))
+
+	// if a userID is provided we check if the user exists
+	// otherwise it will be an unset operation
+	if data.userID > 0 {
+		_, err = filter.Get(r.Context(), db)
+		if err != nil {
+			return nil, mw.NotFound(err)
+		}
+	}
+
+	err = directory.NodeUpdateDedicated(r.Context(), db, data.nodeID, data.userID)
 	if err != nil {
 		return nil, mw.Error(err)
 	}

--- a/pkg/directory/farms_handlers.go
+++ b/pkg/directory/farms_handlers.go
@@ -156,11 +156,10 @@ func (f *FarmAPI) deleteNodeFromFarm(r *http.Request) (interface{}, mw.Response)
 func (f *FarmAPI) setNodeDedicated(r *http.Request) (interface{}, mw.Response) {
 	farmID := getFarmID(r.Context())
 
-	type body struct {
+	data := struct {
 		nodeID string
 		userID int64
-	}
-	var data body
+	}{}
 
 	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 		return nil, mw.BadRequest(err)

--- a/pkg/directory/node_handlers.go
+++ b/pkg/directory/node_handlers.go
@@ -56,6 +56,9 @@ func (s *NodeAPI) registerNode(r *http.Request) (interface{}, mw.Response) {
 	n.PublicConfig = nil
 	// and it not immediately deleted
 	n.Deleted = false
+	// set dedicated user id to 0 in case this was passed on accident or on purpose
+	n.Dedicated = 0
+
 	if _, err := s.Add(r.Context(), db, n); err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, mw.NotFound(fmt.Errorf("farm with id:%d does not exists", n.FarmId))

--- a/pkg/directory/node_handlers.go
+++ b/pkg/directory/node_handlers.go
@@ -56,8 +56,6 @@ func (s *NodeAPI) registerNode(r *http.Request) (interface{}, mw.Response) {
 	n.PublicConfig = nil
 	// and it not immediately deleted
 	n.Deleted = false
-	// set dedicated user id to 0 in case this was passed on accident or on purpose
-	n.Dedicated = 0
 
 	if _, err := s.Add(r.Context(), db, n); err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -41,9 +41,9 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("/ip", mw.AsHandlerFunc(farmAPI.deleteFarmIps)).Methods("DELETE").Name("farm-delete-ip-v1")
 	farmsAuthenticated.HandleFunc("", mw.AsHandlerFunc(farmAPI.updateFarm)).Methods("PUT").Name("farm-update-v1")
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
+	farmsAuthenticated.HandleFunc("/{node_id}/dedicated", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.setNodeDedicated))).Methods("PUT").Name("node-set-node-dedicated")
 	farmsAuthenticated.HandleFunc("/deals", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
 	farmsAuthenticated.HandleFunc("/deals/{threebot_id}", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
-	farmsAuthenticated.HandleFunc("/dedicate-node", mw.AsHandlerFunc(farmAPI.setNodeDedicated)).Methods("POST").Name("farm-set-node-dedicated")
 
 	nodes := api.PathPrefix("/nodes").Subrouter()
 	nodesAuthenticated := api.PathPrefix("/nodes").Subrouter()

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -41,7 +41,7 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("/ip", mw.AsHandlerFunc(farmAPI.deleteFarmIps)).Methods("DELETE").Name("farm-delete-ip-v1")
 	farmsAuthenticated.HandleFunc("", mw.AsHandlerFunc(farmAPI.updateFarm)).Methods("PUT").Name("farm-update-v1")
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
-	farmsAuthenticated.HandleFunc("/{node_id}/dedicated", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.setNodeDedicated))).Methods("PUT").Name("node-set-node-dedicated")
+
 	farmsAuthenticated.HandleFunc("/deals", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
 	farmsAuthenticated.HandleFunc("/deals/{threebot_id}", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
 
@@ -61,6 +61,7 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	nodesAuthenticated.HandleFunc("/{node_id}/interfaces", mw.AsHandlerFunc(nodeAPI.Requires("node_id", nodeAPI.registerIfaces))).Methods("POST").Name("node-interfaces-v1")
 	nodesAuthenticated.HandleFunc("/{node_id}/ports", mw.AsHandlerFunc(nodeAPI.Requires("node_id", nodeAPI.registerPorts))).Methods("POST").Name("node-set-ports-v1")
 	userAuthenticated.HandleFunc("/{node_id}/configure_public", mw.AsHandlerFunc(nodeAPI.Requires("node_id", nodeAPI.configurePublic))).Methods("POST").Name("node-configure-public-v1")
+	userAuthenticated.HandleFunc("/{node_id}/dedicated", mw.AsHandlerFunc(nodeAPI.Requires("node_id", nodeAPI.setNodeDedicated))).Methods("PUT").Name("node-set-node-dedicated")
 	userAuthenticated.HandleFunc("/{node_id}/configure_free", mw.AsHandlerFunc(nodeAPI.Requires("node_id", nodeAPI.configureFreeToUse))).Methods("POST").Name("node-configure-free-v1")
 	nodesAuthenticated.HandleFunc("/{node_id}/capacity", mw.AsHandlerFunc(nodeAPI.Requires("node_id", nodeAPI.registerCapacity))).Methods("POST").Name("node-capacity-v1")
 	nodesAuthenticated.HandleFunc("/{node_id}/uptime", mw.AsHandlerFunc(nodeAPI.Requires("node_id", nodeAPI.updateUptimeHandler))).Methods("POST").Name("node-uptime-v1")

--- a/pkg/directory/setup.go
+++ b/pkg/directory/setup.go
@@ -43,6 +43,7 @@ func Setup(parent *mux.Router, db *mongo.Database) error {
 	farmsAuthenticated.HandleFunc("/{node_id}", mw.AsHandlerFunc(nodeAPI.Requires("node_id", farmAPI.deleteNodeFromFarm))).Methods("DELETE").Name("farm-node-delete-v1")
 	farmsAuthenticated.HandleFunc("/deals", mw.AsHandlerFunc(farmAPI.createOrUpdateFarmCustomPrice)).Methods("POST", "PUT").Name("farm-update-prices-v1")
 	farmsAuthenticated.HandleFunc("/deals/{threebot_id}", mw.AsHandlerFunc(farmAPI.deleteFarmCustomPrice)).Methods("DELETE").Name("farm-delete-prices-v1")
+	farmsAuthenticated.HandleFunc("/dedicate-node", mw.AsHandlerFunc(farmAPI.setNodeDedicated)).Methods("POST").Name("farm-set-node-dedicated")
 
 	nodes := api.PathPrefix("/nodes").Subrouter()
 	nodesAuthenticated := api.PathPrefix("/nodes").Subrouter()

--- a/pkg/directory/types/node.go
+++ b/pkg/directory/types/node.go
@@ -309,6 +309,13 @@ func NodeSetWGPorts(ctx context.Context, db *mongo.Database, nodeID string, port
 	})
 }
 
+// NodeUpdateDedicated sets node dedicated user id
+func NodeUpdateDedicated(ctx context.Context, db *mongo.Database, nodeID string, dedicated int64) error {
+	return nodeUpdate(ctx, db, nodeID, bson.M{
+		"dedicated": dedicated,
+	})
+}
+
 // NodePushProof push proof to node
 func NodePushProof(ctx context.Context, db *mongo.Database, nodeID string, proof generated.Proof) error {
 	if nodeID == "" {

--- a/pkg/workloads/reservation.go
+++ b/pkg/workloads/reservation.go
@@ -114,10 +114,10 @@ func (a *API) create(r *http.Request) (interface{}, mw.Response) {
 		return nil, mw.BadRequest(errors.Wrapf(err, "cannot find node with id '%s'", workload.GetNodeID()))
 	}
 
-	// if a node has a userID assigned it means it will only take reservations from this user
-	if node.UserID != 0 {
-		if workload.GetCustomerTid() != int64(node.UserID) {
-			return nil, mw.UnAuthorized(fmt.Errorf("node accepts only reservations from user with id: %d", node.UserID))
+	// if a node has a dedicated ID assigned it means it will only take reservations from this user
+	if node.Dedicated != 0 {
+		if workload.GetCustomerTid() != int64(node.Dedicated) {
+			return nil, mw.UnAuthorized(fmt.Errorf("node accepts only reservations from user with id: %d", node.Dedicated))
 		}
 	}
 


### PR DESCRIPTION
This PR implements the actual operation once the node is reserved. It will allow only workloads from that user to be deployed on this node. The PR though does not implement ways to reserve a node, nor the billing part.

We need input on:
- Who is gonna set this flag? the farmer? 
- Once the node is reserved, how this gonna affect billing. Should the user still be billed for only the deployed workloads (the way we do now) or other changes is needed.
- 