### PR TITLE
Payment aggregation

### DIFF
--- a/cmds/tfexplorer/main.go
+++ b/cmds/tfexplorer/main.go
@@ -204,7 +204,7 @@ func createServer(f flags, client *mongo.Client, dropEscrowData bool) (*http.Ser
 	}
 
 	go e.Run(context.Background())
-	go e.Payout(context.Background())
+	go e.PaymentsLoop(context.Background())
 	if f.enablePProf {
 		runtime.SetBlockProfileRate(1)
 		router.PathPrefix("/debug/").Handler(http.DefaultServeMux)

--- a/cmds/tfexplorer/main.go
+++ b/cmds/tfexplorer/main.go
@@ -202,7 +202,9 @@ func createServer(f flags, client *mongo.Client, dropEscrowData bool) (*http.Ser
 		log.Info().Msg("escrow disabled")
 		e = escrow.NewFree(db.Database())
 	}
-
+	if err := e.RepushPendingPayments(); err != nil {
+		log.Fatal().Err(err).Msg("couldn't set transaction states")
+	}
 	go e.Run(context.Background())
 	go e.PaymentsLoop(context.Background())
 	if f.enablePProf {

--- a/cmds/tfexplorer/main.go
+++ b/cmds/tfexplorer/main.go
@@ -204,7 +204,7 @@ func createServer(f flags, client *mongo.Client, dropEscrowData bool) (*http.Ser
 	}
 
 	go e.Run(context.Background())
-
+	go e.Payout(context.Background())
 	if f.enablePProf {
 		runtime.SetBlockProfileRate(1)
 		router.PathPrefix("/debug/").Handler(http.DefaultServeMux)

--- a/pkg/escrow/escrow.go
+++ b/pkg/escrow/escrow.go
@@ -13,7 +13,7 @@ type (
 	// Escrow are responsible for the payment flow of a reservation
 	Escrow interface {
 		Run(ctx context.Context) error
-		Payout(ctx context.Context) error
+		PaymentsLoop(ctx context.Context) error
 		CapacityReservation(reservation capacitytypes.Reservation, supportedCurrencies []string) (types.CustomerCapacityEscrowInformation, error)
 		PaidCapacity() <-chan schema.ID
 	}
@@ -35,8 +35,8 @@ func (e *Free) Run(ctx context.Context) error {
 	return nil
 }
 
-// Run implements the escrow interface
-func (e *Free) Payout(ctx context.Context) error {
+// PaymentsLoop implements the escrow interface
+func (e *Free) PaymentsLoop(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/escrow/escrow.go
+++ b/pkg/escrow/escrow.go
@@ -13,6 +13,7 @@ type (
 	// Escrow are responsible for the payment flow of a reservation
 	Escrow interface {
 		Run(ctx context.Context) error
+		Payout(ctx context.Context) error
 		CapacityReservation(reservation capacitytypes.Reservation, supportedCurrencies []string) (types.CustomerCapacityEscrowInformation, error)
 		PaidCapacity() <-chan schema.ID
 	}
@@ -31,6 +32,11 @@ func NewFree(db *mongo.Database) *Free {
 
 // Run implements the escrow interface
 func (e *Free) Run(ctx context.Context) error {
+	return nil
+}
+
+// Run implements the escrow interface
+func (e *Free) Payout(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/escrow/escrow.go
+++ b/pkg/escrow/escrow.go
@@ -14,6 +14,7 @@ type (
 	Escrow interface {
 		Run(ctx context.Context) error
 		PaymentsLoop(ctx context.Context) error
+		RepushPendingPayments() error
 		CapacityReservation(reservation capacitytypes.Reservation, supportedCurrencies []string) (types.CustomerCapacityEscrowInformation, error)
 		PaidCapacity() <-chan schema.ID
 	}
@@ -54,4 +55,9 @@ func (e *Free) CapacityReservation(reservation capacitytypes.Reservation, _ []st
 // PaidCapacity implements the escrow interface
 func (e *Free) PaidCapacity() <-chan schema.ID {
 	return e.capacityChan
+}
+
+// RepushPendingPayments implements the escrow interface
+func (e *Free) RepushPendingPayments() error {
+	return nil
 }

--- a/pkg/escrow/stellar.go
+++ b/pkg/escrow/stellar.go
@@ -325,7 +325,7 @@ func (e *Stellar) processFailedPayments(herr *horizonclient.Error, jobs []stella
 				escrowInfo.CancellationPending = false
 				escrowInfo.Canceled = true // we gave up
 				failed := types.FailedPaymentInfo{
-					ReservatoinID: j.ID,
+					ReservationID: j.ID,
 					MemoText:      j.Memo,
 					ErrorCodes:    operationCodes[curOpIdx-len(j.Payments) : curOpIdx],
 					EnvelopeXDR:   xdr,

--- a/pkg/escrow/stellar.go
+++ b/pkg/escrow/stellar.go
@@ -340,7 +340,7 @@ func (e *Stellar) PaymentsLoop(ctx context.Context) error {
 					jobMap[len(payments)] = len(jobs) - 1
 					payments = append(payments, payment)
 				}
-				if len(payments) >= MaxOperationsPerTx*.8 || len(secrets) >= MaxSignaturesPerTx*.8 {
+				if len(payments) >= MaxOperationsPerTx*.8 || len(secrets) >= MaxSignaturesPerTx-1 {
 					ready = true
 				}
 			default:

--- a/pkg/escrow/stellar.go
+++ b/pkg/escrow/stellar.go
@@ -82,7 +82,7 @@ const (
 	balanceCheckInterval = time.Second * 5
 
 	// maximum time for a capacity reservation
-	capacityReservationTimeout = time.Minute * 1
+	capacityReservationTimeout = time.Hour * 1
 )
 
 const (
@@ -245,7 +245,6 @@ func (e *Stellar) Payout(ctx context.Context) error {
 		for !ready {
 			select {
 			case <-ctx.Done():
-				log.Debug().Msg("we are done")
 				log.Info().Msg("escrow context done, exiting")
 				return nil
 
@@ -276,7 +275,6 @@ func (e *Stellar) Payout(ctx context.Context) error {
 				if len(secrets) > 0 {
 					ready = true
 				} else {
-					log.Debug().Msg("waiting")
 					time.Sleep(1 * time.Second)
 				}
 			}

--- a/pkg/escrow/stellar.go
+++ b/pkg/escrow/stellar.go
@@ -347,8 +347,7 @@ func (e *Stellar) PaymentsLoop(ctx context.Context) error {
 				if len(secrets) > 0 {
 					ready = true
 				} else {
-					log.Debug().Msg("waiting")
-					time.Sleep(70 * time.Second)
+					time.Sleep(1 * time.Second)
 				}
 			}
 		}

--- a/pkg/escrow/types/failed.go
+++ b/pkg/escrow/types/failed.go
@@ -20,9 +20,9 @@ type (
 		// MemoText the memo text of the payment request
 		MemoText string `bson:"memo_text"`
 		// TxSequence the sequence number of the
-		ErrorCode string `bson:"error_code"`
+		ErrorCodes []string `bson:"error_code"`
 		// TxSequence the sequence number of the
-		EnvelopeXDR string `bson:"error_code"`
+		EnvelopeXDR string `bson:"xdr"`
 		// OperationIDs list of indices in the transaction not the stellar operation id
 		ResultString string `bson:"result_string"`
 	}

--- a/pkg/escrow/types/failed.go
+++ b/pkg/escrow/types/failed.go
@@ -33,12 +33,6 @@ func FailedPaymentInfoInfoCreate(ctx context.Context, db *mongo.Database, info F
 	col := db.Collection(FailedPaymentsCollectoins)
 	_, err := col.InsertOne(ctx, info)
 	if err != nil {
-		if merr, ok := err.(mongo.WriteException); ok {
-			errCode := merr.WriteErrors[0].Code
-			if errCode == 11000 {
-				return ErrEscrowExists
-			}
-		}
 		return err
 	}
 	return nil

--- a/pkg/escrow/types/failed.go
+++ b/pkg/escrow/types/failed.go
@@ -15,8 +15,8 @@ const (
 type (
 	// FailedPaymentInfo contains info about failed payment
 	FailedPaymentInfo struct {
-		// ID of the pool
-		ReservatoinID schema.ID `bson:"res_id"`
+		// ReservationID of the pool
+		ReservationID schema.ID `bson:"res_id"`
 		// MemoText the memo text of the payment request
 		MemoText string `bson:"memo_text"`
 		// TxSequence the sequence number of the

--- a/pkg/escrow/types/failed.go
+++ b/pkg/escrow/types/failed.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"context"
+
+	"github.com/threefoldtech/tfexplorer/schema"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const (
+	// CapacityEscrowCollection db collection for mapping between payment request and transaction sequence number and operations ids
+	FailedPaymentsCollectoins = "capacity-failed-transactions"
+)
+
+type (
+	FailedPaymentInfo struct {
+		// ID of the pool
+		ReservatoinID schema.ID `bson:"res_id"`
+		// MemoText the memo text of the payment request
+		MemoText string `bson:"memo_text"`
+		// TxSequence the sequence number of the
+		ErrorCode string `bson:"error_code"`
+		// TxSequence the sequence number of the
+		EnvelopeXDR string `bson:"error_code"`
+		// OperationIDs list of indices in the transaction not the stellar operation id
+		ResultString string `bson:"result_string"`
+	}
+)
+
+// FailedPaymentInfoInfoCreate creates the new failed payment info document
+func FailedPaymentInfoInfoCreate(ctx context.Context, db *mongo.Database, info FailedPaymentInfo) error {
+	col := db.Collection(FailedPaymentsCollectoins)
+	_, err := col.InsertOne(ctx, info)
+	if err != nil {
+		if merr, ok := err.(mongo.WriteException); ok {
+			errCode := merr.WriteErrors[0].Code
+			if errCode == 11000 {
+				return ErrEscrowExists
+			}
+		}
+		return err
+	}
+	return nil
+}

--- a/pkg/escrow/types/failed.go
+++ b/pkg/escrow/types/failed.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	// CapacityEscrowCollection db collection for mapping between payment request and transaction sequence number and operations ids
+	// FailedPaymentsCollectoins db collection for failed payments
 	FailedPaymentsCollectoins = "capacity-failed-transactions"
 )
 
 type (
+	// FailedPaymentInfo contains info about failed payment
 	FailedPaymentInfo struct {
 		// ID of the pool
 		ReservatoinID schema.ID `bson:"res_id"`

--- a/pkg/escrow/types/memos.go
+++ b/pkg/escrow/types/memos.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/threefoldtech/tfexplorer/schema"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const (
+	// CapacityEscrowCollection db collection for mapping between payment request and transaction sequence number and operations ids
+	CapacityMemoTextCollection = "capacity-memo-text"
+)
+
+type (
+	CapacityMemoTextInfo struct {
+		// ID of the pool
+		ID schema.ID `bson:"_id"`
+		// MemoText the memo text of the payment request
+		MemoText string `bson:"memo_text"`
+		// TxSequence the sequence number of the
+		TxSequence string `bson:"tx_sequence"`
+		// OperationIDs list of indices in the transaction not the stellar operation id
+		OperationIDs []int `bson:"operation_ids"`
+	}
+)
+
+// CapacityMemoTextInfo creates the capacity memo text info document
+func CapacityMemoTextInfoCreate(ctx context.Context, db *mongo.Database, info CapacityMemoTextInfo) error {
+	col := db.Collection(CapacityMemoTextCollection)
+	_, err := col.InsertOne(ctx, info)
+	if err != nil {
+		if merr, ok := err.(mongo.WriteException); ok {
+			errCode := merr.WriteErrors[0].Code
+			if errCode == 11000 {
+				return ErrEscrowExists
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+// GetAllActiveCapacityReservationPaymentInfos get all active reservation payment information
+func CapacityMemoTextInfoGet(ctx context.Context, db *mongo.Database, memo string) ([]CapacityMemoTextInfo, error) {
+	filter := bson.M{"memo_text": memo}
+	cursor, err := db.Collection(CapacityMemoTextCollection).Find(ctx, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get cursor over capacity memo text infos")
+	}
+	memoInfos := make([]CapacityMemoTextInfo, 0)
+	err = cursor.All(ctx, &memoInfos)
+	if err != nil {
+		err = errors.Wrap(err, "failed to decode capacity memo text information")
+	}
+	return memoInfos, err
+}

--- a/pkg/escrow/types/memos.go
+++ b/pkg/escrow/types/memos.go
@@ -5,20 +5,18 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/threefoldtech/tfexplorer/schema"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 const (
-	// CapacityEscrowCollection db collection for mapping between payment request and transaction sequence number and operations ids
+	// CapacityMemoTextCollection db collection for mapping between payment request and transaction sequence number and operations ids
 	CapacityMemoTextCollection = "capacity-memo-text"
 )
 
 type (
+	// CapacityMemoTextInfo mapping between the memo text and the transaction sequence number and operations indices in the tx
 	CapacityMemoTextInfo struct {
-		// ID of the pool
-		ID schema.ID `bson:"_id"`
 		// MemoText the memo text of the payment request
 		MemoText string `bson:"memo_text"`
 		// TxSequence the sequence number of the
@@ -28,7 +26,7 @@ type (
 	}
 )
 
-// CapacityMemoTextInfo creates the capacity memo text info document
+// CapacityMemoTextInfoCreate creates the capacity memo text info document
 func CapacityMemoTextInfoCreate(ctx context.Context, db *mongo.Database, info CapacityMemoTextInfo) error {
 	col := db.Collection(CapacityMemoTextCollection)
 	_, err := col.InsertOne(ctx, info)
@@ -44,7 +42,7 @@ func CapacityMemoTextInfoCreate(ctx context.Context, db *mongo.Database, info Ca
 	return nil
 }
 
-// GetAllActiveCapacityReservationPaymentInfos get all active reservation payment information
+// CapacityMemoTextInfoGet get memo text transaction mapping
 func CapacityMemoTextInfoGet(ctx context.Context, db *mongo.Database, memo string) ([]CapacityMemoTextInfo, error) {
 	filter := bson.M{"memo_text": memo}
 	cursor, err := db.Collection(CapacityMemoTextCollection).Find(ctx, filter)

--- a/pkg/escrow/types/memos.go
+++ b/pkg/escrow/types/memos.go
@@ -31,12 +31,6 @@ func CapacityMemoTextInfoCreate(ctx context.Context, db *mongo.Database, info Ca
 	col := db.Collection(CapacityMemoTextCollection)
 	_, err := col.InsertOne(ctx, info)
 	if err != nil {
-		if merr, ok := err.(mongo.WriteException); ok {
-			errCode := merr.WriteErrors[0].Code
-			if errCode == 11000 {
-				return ErrEscrowExists
-			}
-		}
 		return err
 	}
 	return nil

--- a/pkg/escrow/types/setup.go
+++ b/pkg/escrow/types/setup.go
@@ -38,5 +38,19 @@ func Setup(ctx context.Context, db *mongo.Database) error {
 		log.Error().Err(err).Msg("failed to initialize reservation payment index")
 	}
 
+	memos := db.Collection(CapacityMemoTextCollection)
+	_, err = memos.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.M{"_id": 1},
+		},
+		{
+			Keys:    bson.M{"memo_text": 1},
+			Options: options.Index().SetUnique(false),
+		},
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("failed to initialize failed payment index")
+	}
+
 	return err
 }

--- a/pkg/stellar/retry.go
+++ b/pkg/stellar/retry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/stellar/go/clients/horizonclient"
+	"github.com/threefoldtech/tfexplorer/schema"
 )
 
 type (
@@ -65,9 +66,9 @@ func (r *retryWallet) error(op, memo string, err error) error {
 // 	return
 // }
 
-func (r *retryWallet) Refund(encryptedSeed string, memo string, asset Asset) (err error) {
+func (r *retryWallet) Refund(encryptedSeed string, memo string, asset Asset, batchTxs *BatchTransactionsInfo, pn chan PayoutJob, reservation_id schema.ID) (err error) {
 	err = r.backoff(func() error {
-		err = r.Wallet.Refund(encryptedSeed, memo, asset)
+		err = r.Wallet.Refund(encryptedSeed, memo, asset, batchTxs, pn, reservation_id)
 		return r.error("Refund", memo, err)
 	})
 

--- a/pkg/stellar/retry.go
+++ b/pkg/stellar/retry.go
@@ -66,9 +66,9 @@ func (r *retryWallet) error(op, memo string, err error) error {
 // 	return
 // }
 
-func (r *retryWallet) Refund(encryptedSeed string, memo string, asset Asset, batchTxs *BatchTransactionsInfo, pn chan PayoutJob, reservation_id schema.ID) (err error) {
+func (r *retryWallet) Refund(encryptedSeed string, memo string, asset Asset, batchTxs *BatchTransactionsInfo, pn chan PayoutJob, ReservationID schema.ID) (err error) {
 	err = r.backoff(func() error {
-		err = r.Wallet.Refund(encryptedSeed, memo, asset, batchTxs, pn, reservation_id)
+		err = r.Wallet.Refund(encryptedSeed, memo, asset, batchTxs, pn, ReservationID)
 		return r.error("Refund", memo, err)
 	})
 


### PR DESCRIPTION
### Changes

1. Make all payments and refunds go through the paymentsChannel and aggregate them until nothing comes in, the number of payments exceeds 80% of stellar limit, (100) or the number of signatures exceeds the limit 20 - 1 (the funding wallet signature).
2. FarmerPayouts are retried 2 times, in case of failure, it gets pushed back to the tail of the queue.
3. In case a farmer payout fails, a client refund is issued to the client with retries = 6, in case this fails it gets stored in the db.
4. In case the transaction failed, the successful payouts are repushed (they doesn't take effect since the whole tx failed), the failed ones decreases the retries and gets pushed back.
5. Since paying farmers are bundled, they doesn't contain memo text. This is fixed by storing in mongo the mapping from memo text to the transaction sequence number and the operation indices. This is used instead of ids because they are available before submitting the transaction (in case the transaction is commited but the explorer didn't know about it).
6. Cancellation-pending state is added to a avoid repushing expired payout refunds to the queue, and to restore them at explorer start.
7. When the explorer is started, all paid non-released payouts and cancellation pending non-cancelled is repushed to the payment queue if they didn't expire.